### PR TITLE
add class blacklist

### DIFF
--- a/zscript/Event-Handlers.zsc
+++ b/zscript/Event-Handlers.zsc
@@ -34,6 +34,26 @@ class RTSpawnAmmo play
 // One handler to rule them all. 
 class RadTechHandler : EventHandler
 {
+
+	// List of persistent classes to completely ignore. 
+	// This -should- mean this mod has no performance impact. 
+	static const class<actor> blacklist[] =
+	{
+		"HDSmoke",
+		"BloodTrail",
+		"CheckPuff",
+		"WallChunk",
+		"HDBulletPuff",
+		"HDFireballTail",
+		"ReverseImpBallTail",
+		"HDSmokeChunk",
+		"ShieldSpark",
+		"HDFlameRed",
+		"HDMasterBlood",
+		"PlantBit",
+		"HDBulletActor"
+	};
+
 	// List of weapon-ammo associations.
 	// Used for ammo-use association on ammo spawn (happens very often). 
 	array<RTSpawnAmmo> ammospawnlist;
@@ -384,6 +404,13 @@ class RadTechHandler : EventHandler
 		if(!cvarsAvailable)
 			init();
 		
+		
+		for(i = 0; i < blacklist.size(); i++)
+		{
+			if (e.thing is blacklist[i])
+				return;
+		}
+		
 		// Checks for null events. 
 		if(!e.Thing)
 		{
@@ -429,7 +456,7 @@ class RadTechHandler : EventHandler
 			
 			// if an item is owned or is an ammo (doesn't retain owner ptr), 
 			// do not replace it. 
-			if ((prespawn || persist) && (!owned && (!ammo_ptr || prespawn))
+			if ((prespawn || persist) && (!owned && (!ammo_ptr || prespawn)))
 			{
 				int original_i = i;
 				for(j = 0; j < itemspawnlist[original_i].spawnreplacessize; j++)


### PR DESCRIPTION
adds a class blacklist (which for persistent spawning junk like smoke, should prevent lag spikes),
I was intending to bolt this onto the last branch, but it was merged before I could get it out. The class-list is taken directly from performance pal, since I had a list of generally useless HD-Classes lying around. 