### PR TITLE
- Event Handler: Return if MapName is Range.

### DIFF
--- a/zscript/Event-Handlers.zsc
+++ b/zscript/Event-Handlers.zsc
@@ -563,6 +563,12 @@ class RadTechHandler : EventHandler
 		// loop controls.
 		int i, j;
 		bool isAmmo = false;
+
+		// Return if range.
+        if(level.MapName ~== "RANGE")
+        {
+                return;
+        }
 		
 		// Populates the main arrays if they haven't been already. 
 		if(!cvarsAvailable)


### PR DESCRIPTION
This should prevent stuff from spawning on the range to keep it more consistently clean and prevent potential issues.