### PR TITLE
Refactor Combat Shotgun Iron Sight Graphics

### DIFF
--- a/TEXTURES
+++ b/TEXTURES
@@ -727,6 +727,20 @@ sprite fbpsite, 5,13
 	patch fbpsite, 0, 0{}
 }
 
+// Combat Shotgun
+
+// Front Sight
+sprite csgftsit, 5,13
+{
+	patch sgfrntsit, 0, 0{}
+}
+
+// Invisible Back Sight
+sprite csgbksit, 0,0
+{
+	// There's no back sight on the weapon sprites
+}
+
 // Golden Single-Action Revolver
 
 sprite C45GA0,11,17{

--- a/zscript/Combat Shotgun/wep_combatshotgun.zs
+++ b/zscript/Combat Shotgun/wep_combatshotgun.zs
@@ -102,12 +102,11 @@ class HDCombatShotgun:HDShotgun{ //hope you're good at pumping ;)
 		);
 		vector2 bobb=bob*2.2; //2x more bobbing because there's no stock
 		sb.drawimage(
-			"frntsite",(0,0)+bobb,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP
+			"csgftsit",(0,0)+bobb,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP
 		);
 		sb.SetClipRect(cx,cy,cw,ch);
 		sb.drawimage(
-			"sgbaksit",(0,0)+bob,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP,
-			alpha:0.0//there's no back sight on the weapon sprites
+			"csgbksit",(0,0)+bob,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP
 		);
 	}
 	override double gunmass(){


### PR DESCRIPTION
This should allow reskins to replace them if needed, as well as leave the "invisible sights" up to the TEXTURES definition rather than hardcoded in ZScript