### PR TITLE
Sights updates and handling fixes

### DIFF
--- a/zscript/10mm Weaponry/wep_10mmPistol.zs
+++ b/zscript/10mm Weaponry/wep_10mmPistol.zs
@@ -19,7 +19,7 @@ class HD10mmPistol:HDHandgun{
 //		inventory.pickupmessage "You got the 10mm pistol! It really packs a punch!";
 		tag "$TAG_10PIS";
 		hdweapon.refid "p1m";//Pistol, 10 millimeter.
-		hdweapon.barrelsize 10,0.3,0.5;
+		hdweapon.barrelsize 19,0.3,0.5;
 
 		hdweapon.loadoutcodes "
 			\cuselectfire - 0/1, whether it has a fire selector
@@ -98,7 +98,7 @@ class HD10mmPistol:HDHandgun{
 		int cx,cy,cw,ch;
 		[cx,cy,cw,ch]=screen.GetClipRect();
 		vector2 scc;
-		vector2 bobb=bob*1.6;
+		vector2 bobb=bob*1.3;
 
 		//if slide is pushed back, throw sights off line
 		if(hpl.player.getpsprite(PSP_WEAPON).frame>=2){

--- a/zscript/10mm Weaponry/wep_sigcow.zs
+++ b/zscript/10mm Weaponry/wep_sigcow.zs
@@ -322,7 +322,7 @@ if(!punchee.countinv("HDArmourWorn")){
 				-16+bob.x,-4+bob.y,32,16,
 				sb.DI_SCREEN_CENTER
 			);
-			bobb.y=clamp(bobb.y,-8,8);
+			//bobb.y=clamp(bobb.y,-8,8);
 			sb.drawimage(
 				"smgfrntsit",(0,0)+bobb,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP
 			);

--- a/zscript/Colt 1911/wep_Colt1911.zs
+++ b/zscript/Colt 1911/wep_Colt1911.zs
@@ -20,7 +20,7 @@ class HDColt1911:HDHandgun{
 //		inventory.pickupmessage "You got the Colt 1911! Semper Fi!";
 		tag "$TAG_C19";
 		hdweapon.refid "c19";
-		hdweapon.barrelsize 10,0.3,0.5;
+		hdweapon.barrelsize 19,0.3,0.5;
 	}
 
 	override string pickupmessage(){
@@ -95,7 +95,7 @@ class HDColt1911:HDHandgun{
 		int cx,cy,cw,ch;
 		[cx,cy,cw,ch]=screen.GetClipRect();
 		vector2 scc;
-		vector2 bobb=bob*1.6;
+		vector2 bobb=bob*1.3;
 
 		//if slide is pushed back, throw sights off line
 		if(hpl.player.getpsprite(PSP_WEAPON).frame>=2){

--- a/zscript/Doomed Hunter/wep_doomhunter.zs
+++ b/zscript/Doomed Hunter/wep_doomhunter.zs
@@ -119,7 +119,7 @@ override void postbeginplay(){
 			-16+bob.x,-32+bob.y,32,40,
 			sb.DI_SCREEN_CENTER
 		);
-		vector2 bobb=bob*2;
+		vector2 bobb=bob*1.1;
 //		bobb.y=clamp(bobb.y,-8,8);
 		sb.drawimage(
 			"frntsite",(0,0)+bobb,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP

--- a/zscript/Explosive Shotgun/wep_explosiveHunter.zs
+++ b/zscript/Explosive Shotgun/wep_explosiveHunter.zs
@@ -127,7 +127,7 @@ override void failedpickupunload(){
 			-16+bob.x,-32+bob.y,32,40,
 			sb.DI_SCREEN_CENTER
 		);
-		vector2 bobb=bob*2;
+		vector2 bobb=bob*1.1;
 //		bobb.y=clamp(bobb.y,-8,8);
 		sb.drawimage(
 			"redfsite",(0,0)+bobb,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP

--- a/zscript/FP-45 Liberator/wep_fp45.zs
+++ b/zscript/FP-45 Liberator/wep_fp45.zs
@@ -84,7 +84,7 @@ class HDFP45:HDHandgun{
 		int cx,cy,cw,ch;
 		[cx,cy,cw,ch]=screen.GetClipRect();
 		vector2 scc;
-		vector2 bobb=bob*1.6;
+		vector2 bobb=bob*1.3;
 	
 			sb.SetClipRect(
 				-8+bob.x,-9+bob.y,16,15,

--- a/zscript/Golden Gun/wep_GoldSArevolver.zs
+++ b/zscript/Golden Gun/wep_GoldSArevolver.zs
@@ -18,7 +18,7 @@ class HDGoldSingleActionRevolver:HDHandgun{
 		obituary "$OB_GOLDENGUN";
 		tag "$TAG_GOLDSINGLEACTION";
 		hdweapon.refid "gsa";//golden single action
-		hdweapon.barrelsize 6,0.3,0.5;
+		hdweapon.barrelsize 20,0.3,0.5;
 	}
 	override string pickupmessage(){
 		return Stringtable.Localize("$PICKUP_GOLDENSINGLEACTION");
@@ -27,10 +27,10 @@ class HDGoldSingleActionRevolver:HDHandgun{
 		double blk=0;
 		for(int i=GSAS_CYL1;i<=GSAS_CYL6;i++){
 			int wi=weaponstatus[i];
-			if(wi==GSAS_MASTERBALL)blk+=1.3;
-			else if(wi==GSAS_NINEMIL)blk+=1.3;
+			if(wi==GSAS_MASTERBALL)blk+=0.3;
+			else if(wi==GSAS_NINEMIL)blk+=0.3;
 		}
-		return blk+15;
+		return blk+9;
 	}
 	override double weaponbulk(){
 		double blk=0;
@@ -115,7 +115,7 @@ if(ninemil>0){
 		int cx,cy,cw,ch;
 		[cx,cy,cw,ch]=screen.GetClipRect();
 		vector2 scc;
-		vector2 bobb=bob*1.6;
+		vector2 bobb=bob*1.3;
 
 		sb.SetClipRect(
 			-8+bob.x,-9+bob.y,16,15,

--- a/zscript/Juan 9mm Pistol/wep_juan.zs
+++ b/zscript/Juan 9mm Pistol/wep_juan.zs
@@ -23,7 +23,7 @@ class HDHorseshoePistol:HDHandgun{
 		obituary "$OB_JUAN";
 		tag "$TAG_JUANPIS";
 		hdweapon.refid "jua";
-		hdweapon.barrelsize 10,0.3,0.5;
+		hdweapon.barrelsize 19,0.3,0.5;
 
 		hdweapon.loadoutcodes "
 			\cuselectfire - 0/1, whether it has a fire selector
@@ -190,7 +190,7 @@ class HDHorseshoePistol:HDHandgun{
 		int cx,cy,cw,ch;
 		[cx,cy,cw,ch]=screen.GetClipRect();
 		vector2 scc;
-		vector2 bobb=bob*1.6;
+		vector2 bobb=bob*1.3;
 
 		//if slide is pushed back, throw sights off line
 		if(hpl.player.getpsprite(PSP_WEAPON).frame>=2){

--- a/zscript/Less Lethal Hunter/wep_LLhunter.zs
+++ b/zscript/Less Lethal Hunter/wep_LLhunter.zs
@@ -102,7 +102,7 @@ class LLHunter:HDLLShotgun{
 			-16+bob.x,-32+bob.y,32,40,
 			sb.DI_SCREEN_CENTER
 		);
-		vector2 bobb=bob*2;
+		vector2 bobb=bob*1.1;
 //		bobb.y=clamp(bobb.y,-8,8);
 		sb.drawimage(
 			"fblusite",(0,0)+bobb,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP

--- a/zscript/Minerva/wep_minerva.zs
+++ b/zscript/Minerva/wep_minerva.zs
@@ -44,9 +44,9 @@ class MinervaChaingun:ZM66ScopeHaver{
 		weapon.slotnumber 4;
 		weapon.slotpriority 1;
 		weapon.kickback 24;
-		weapon.bobrangex 1.4;
-		weapon.bobrangey 3.5;
-		weapon.bobspeed 2.1;
+		weapon.bobrangex 1.2;
+		weapon.bobrangey 1.5;
+		weapon.bobspeed 1.8;
 		weapon.bobstyle "normal";
 		obituary "$OB_MINERVA";
 		hdweapon.barrelsize 30,3,4;
@@ -80,6 +80,26 @@ override void postbeginplay(){
 		else if(bc>100)msg=msg..Stringtable.Localize("$PICKUP_MINERVADAMAGE100");
 		return msg;
 	}
+
+	override void DoEffect(){
+		let hdp=hdplayerpawn(owner);
+		if(hdp){
+			//droop downwards
+			if(
+				!hdp.gunbraced
+				&&!!hdp.player
+				&&hdp.player.readyweapon==self
+				&&hdp.strength
+				&&hdp.pitch<frandom(5,8)
+				&&!(weaponstatus[0]&BFGF_STRAPPED)
+			)hdp.A_MuzzleClimb((
+				frandom(-0.05,0.05),
+				frandom(0.1,clamp(1-pitch,0.06/hdp.strength,0.12))
+			),(0,0),(0,0),(0,0));
+		}
+		Super.DoEffect();
+	}
+
 
 	override void tick(){
 		super.tick();
@@ -172,18 +192,12 @@ override void postbeginplay(){
 		HDStatusBar sb,HDWeapon hdw,HDPlayerPawn hpl,
 		bool sightbob,vector2 bob,double fov,bool scopeview,actor hpc
 	){
-		if(hpl.countinv("IsMoving")>2){
-			sb.drawimage(
-				"riflsite",(bob.x,bob.y+48),sb.DI_SCREEN_CENTER|sb.DI_ITEM_CENTER
-			);
-			return;
-		}
 		double dotoff=max(abs(bob.x),abs(bob.y));
-		if(dotoff<6){
+		if(dotoff<40){
 			string whichdot=sb.ChooseReflexReticle(hdw.weaponstatus[MNVS_DOT]);
 			sb.drawimage(
-				whichdot,(0,0)+bob*3,sb.DI_SCREEN_CENTER|sb.DI_ITEM_CENTER,
-				alpha:0.8-dotoff*0.04,
+				whichdot,(0,0)+bob*1.18,sb.DI_SCREEN_CENTER|sb.DI_ITEM_CENTER,
+				alpha:0.8-dotoff*0.01,
 				col:0xFF000000|sb.crosshaircolor.GetInt()
 			);
 		}
@@ -232,23 +246,10 @@ override void postbeginplay(){
 	select0:
    TNT1 A 1 ;//wait tic to avoid droop crash bug
 		MNVG A 0 A_CheckDefaultReflexReticle(MNVS_DOT);
-		MNVG A 0 A_Overlay(2,"droop");
 		goto select0bfg;
 	deselect0:
 		MNVG A 0;
 		goto deselect0bfg;
-
-	droop:
-		TNT1 A 1{
-			if(pitch<frandom(5,8)&&(!gunbraced())){
-				A_MuzzleClimb(frandom(-0.06,0.06),
-					frandom(0.1,clamp(1-pitch,
-						hdplayerpawn(self)?0.06/hdplayerpawn(self).strength:0.2
-					,0.25))//decreases aim droop
-				);
-			}
-		}loop;
-
 	ready:
 		MNVG A 1{
 			A_SetCrosshair(21);

--- a/zscript/PPSh-41/wep_ppsh41.zs
+++ b/zscript/PPSh-41/wep_ppsh41.zs
@@ -145,7 +145,7 @@ class HDPPSh41 :HDHandgun{
 		int cx,cy,cw,ch;
 		[cx,cy,cw,ch]=screen.GetClipRect();
 		vector2 scc;
-		vector2 bobb=bob*1.6;
+		vector2 bobb=bob*1.3;
 			
 		sb.SetClipRect(
 			-8+bob.x,-9+bob.y,16,15,

--- a/zscript/Phazer/wep_phazerpistol.zs
+++ b/zscript/Phazer/wep_phazerpistol.zs
@@ -19,7 +19,7 @@ class PhazerPistol:HDHandgun{
 		weapon.ammouse 1;
 		scale 0.6;
 		obituary "$OB_PHAZER";
-		hdweapon.barrelsize 10,1.6,3;
+		hdweapon.barrelsize 19,1.6,3;
 		hdweapon.refid "PHZ";
 		tag "$TAG_PHAZER";
 	}
@@ -104,7 +104,7 @@ class PhazerPistol:HDHandgun{
 			-16+bob.x,-32+bob.y,32,40,
 			sb.DI_SCREEN_CENTER
 		);
-		vector2 bobb=bob*2;
+		vector2 bobb=bob*1.2;
 
 		sb.drawimage(
 			"frntsite",(0,0)+bobb,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP

--- a/zscript/Plasma Buster/wep_plasmabuster.zs
+++ b/zscript/Plasma Buster/wep_plasmabuster.zs
@@ -184,7 +184,7 @@ override void DrawSightPicture(
 			-16+bob.x,-32+bob.y,32,40,
 			sb.DI_SCREEN_CENTER
 		);
-		vector2 bobb=bob*2;
+		vector2 bobb=bob*1.2;
 //		bobb.y=clamp(bobb.y,-8,8);
 		sb.drawimage(
 			"tbfrntsit",(0,0)+bobb,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP

--- a/zscript/STEN/wep_stenmk2s.zs
+++ b/zscript/STEN/wep_stenmk2s.zs
@@ -117,7 +117,7 @@ class HDStenMk2:HDWeapon{
 				-16+bob.x,-4+bob.y,32,16,
 				sb.DI_SCREEN_CENTER
 			);
-			bobb.y=clamp(bobb.y,-8,8);
+			//bobb.y=clamp(bobb.y,-8,8);
 			sb.drawimage(
 				"stenfsit",(0,-5)+bobb,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP
 			);

--- a/zscript/Single Action Revolver/wep_SArevolver.zs
+++ b/zscript/Single Action Revolver/wep_SArevolver.zs
@@ -18,16 +18,16 @@ class HDSingleActionRevolver:HDHandgun{
 		obituary "$OB_RSA";
 		tag "$TAG_SINGLEACTREV";
 		hdweapon.refid "rsa";//revolver, single action
-		hdweapon.barrelsize 12,0.3,0.5; //twice the barrel length
+		hdweapon.barrelsize 22,0.3,0.5; //twice the barrel length
 	}
 	override double gunmass(){
 		double blk=0;
 		for(int i=SING_CYL1;i<=SING_CYL6;i++){
 			int wi=weaponstatus[i];
-			if(wi==SING_MASTERBALL)blk+=0.45;
-			else if(wi==SING_NINEMIL)blk+=0.45;
+			if(wi==SING_MASTERBALL)blk+=0.15;
+			else if(wi==SING_NINEMIL)blk+=0.15;
 		}
-		return blk+7;
+		return blk+6;
 	}
 
 	override string pickupmessage(){
@@ -117,7 +117,7 @@ if(ninemil>0){
 		int cx,cy,cw,ch;
 		[cx,cy,cw,ch]=screen.GetClipRect();
 		vector2 scc;
-		vector2 bobb=bob*1.6;
+		vector2 bobb=bob*1.3;
 
 		sb.SetClipRect(
 			-8+bob.x,-9+bob.y,16,15,

--- a/zscript/Snubnose Revolver/wep_snubnose.zs
+++ b/zscript/Snubnose Revolver/wep_snubnose.zs
@@ -18,7 +18,7 @@ class HDSnubNoseRevolver:HDHandgun{
 		obituary "$OB_SNUBNOSE";
 		tag "$TAG_SNUBNOSE";
 		hdweapon.refid "snb";
-		hdweapon.barrelsize 2,0.3,0.5; //very short barrel, duh
+		hdweapon.barrelsize 16,0.3,0.5; //very short barrel, duh
 	}
 
 	override void postbeginplay(){
@@ -30,10 +30,10 @@ class HDSnubNoseRevolver:HDHandgun{
 		double blk=0;
 		for(int i=SNBN_CYL1;i<=SNBN_CYL6;i++){
 			int wi=weaponstatus[i];
-			if(wi==SNBN_MASTERBALL)blk+=0.35;
-			else if(wi==SNBN_NINEMIL)blk+=0.3;
+			if(wi==SNBN_MASTERBALL)blk+=0.12;
+			else if(wi==SNBN_NINEMIL)blk+=0.1;
 		}
-		return blk+7;
+		return blk+3.5;
 	}
 
 	override string pickupmessage(){
@@ -121,7 +121,7 @@ class HDSnubNoseRevolver:HDHandgun{
 		int cx,cy,cw,ch;
 		[cx,cy,cw,ch]=screen.GetClipRect();
 		vector2 scc;
-		vector2 bobb=bob*1.6;
+		vector2 bobb=bob*1.3;
 
 		sb.SetClipRect(
 			-8+bob.x,-9+bob.y,16,15,

--- a/zscript/TT-33/wep_TT33.zs
+++ b/zscript/TT-33/wep_TT33.zs
@@ -69,7 +69,7 @@ class HDTT33Pistol:HDHandgun{
 		obituary "$OB_TT33";
 		tag "$TAG_TT33";
 		hdweapon.refid "t33";
-		hdweapon.barrelsize 10,0.3,0.5;
+		hdweapon.barrelsize 19,0.3,0.5;
 
 		hdweapon.loadoutcodes "
 			\cuselectfire - 0/1, whether it has a fire selector
@@ -178,7 +178,7 @@ class HDTT33Pistol:HDHandgun{
 		int cx,cy,cw,ch;
 		[cx,cy,cw,ch]=screen.GetClipRect();
 		vector2 scc;
-		vector2 bobb=bob*1.6;
+		vector2 bobb=bob*1.3;
 
 		//if slide is pushed back, throw sights off line
 		if(hpl.player.getpsprite(PSP_WEAPON).frame>=2){


### PR DESCRIPTION
Outdated sightbob values and leftover vertical clamps addressed wherever applicable.
Most pistols adjusted to match changed lengths in HD, I left the particularly small ones alone because they're fine like that.
Single action and golden revolver gunmass calculations massively toned down. They are still substantially touchier than the stock revolver, just not unusable. Snub nose cylinder calculation now matches stock revolver.
Minerva handling heavily edited, no longer bounces all over the screen like crazy and the sight is usable while moving. It might be a thought to make the droop weaker than I left it, but at least it's not pulling harder than the stock vulc anymore.