### PR TITLE
Localize Helptext for all of the weaponry.

### DIFF
--- a/LANGUAGE
+++ b/LANGUAGE
@@ -83,6 +83,8 @@ PICKUP_PPSH41 = "You got the PPSh-41!";
 PICKUP_S99 = "You got the Savage 99!";
 PICKUP_DUCKHUNT = "You got the Duck Hunter!";
 PICKUP_COP357 = "You got the COP .357! What a bastard of a gun!";
+PICKUP_COP357OFF = "You got the COP .357! What a bastard of a gun! Though this one feels a bit off...";
+PICKUP_ESHOTGUN = "You got a shotgun!";
 
 // Item Tags, same as weapons but these are just for the items. - [Ted]
 TAG_10RELOADER = "10mm Auto-Reloader";
@@ -138,6 +140,230 @@ OB_S99 = "%o got sniped by %k's Savage 99";
 OB_DUCKHUNTER = "%o couldn't convince %k it was rabbit season."
 OB_FP45 = "%k liberated %o from life.";
 OB_COP357 = "%o got COP'd by %k.";
+OB_DYNAMITE = "%o was blown to smithereens by %k.";
+OB_ESHOTGUN = "%o got %h the hot bullets of %k's shotgun to die.";
+OB_STENGUN = "%o was silenced by %k's STEN gun.";
+
+// Helptext
+
+// 10mm Reloader
+10RL_HELPTEXT_1 = "  Assemble 10mm rounds\n";
+10RL_HELPTEXT_2 = "  same";
+
+// 10mm Pistol
+10PS_HELPTEXT_1 = "  Semi/Auto\n";
+10PS_HELPTEXT_2 = "  Quick-Swap (if available)\n";
+10PS_HELPTEXT_3 = "  Reload mag\n";
+10PS_HELPTEXT_4 = "  Reload chamber\n";
+
+// Sigcow
+SGCW_HELPTEXT_1 = "  Bayonet Stab\n";
+SGCW_HELPTEXT_2 = "  Reload mag\n";
+SGCW_HELPTEXT_3 = "  Reload chamber\n";
+SGCW_HELPTEXT_4 = "  Semi/Burst/Auto\n";
+
+// Colt 1911
+1911_HELPTEXT_1 = "  Semi/Auto\n";
+1911_HELPTEXT_2 = "  Quick-Swap (if available)\n";
+1911_HELPTEXT_3 = "  Reload mag\n";
+1911_HELPTEXT_4 = "  Reload chamber\n";
+
+// Combat Shotgun
+CBSG_HELPTEXT_1 = "  Shoot\n";
+CBSG_HELPTEXT_2 = "  Pump\n";
+CBSG_HELPTEXT_3 = "  Reload\n";
+
+// COP 357
+C357_HELPTEXT_1 = " Close cylinder\n";
+C357_HELPTEXT_2 = " Remove empty rounds \(double-tap to dump live rounds\)\n";
+C357_HELPTEXT_3 = " Load round \(Hold ";
+C357_HELPTEXT_4 = " to force using 9mm\)\n";
+C357_HELPTEXT_5 = "  Quick-Swap (if available)\n";
+C357_HELPTEXT_6 = " Open chamber\n";
+
+// Doomed Hunter
+DHUN_HELPTEXT_1 = "  Shoot (choke: ";
+DHUN_HELPTEXT_2 = ")\n";
+DHUN_HELPTEXT_3 = "  Pump\n";
+DHUN_HELPTEXT_4 = "  Reload (side saddles first)\n";
+DHUN_HELPTEXT_5 = "  Reload (pockets only)\n";
+DHUN_HELPTEXT_6 = "  Pump/Semi";
+DHUN_HELPTEXT_7 = "/Auto";
+DHUN_HELPTEXT_8 = "  Load side saddles\n";
+DHUN_HELPTEXT_9 = "  Steal ammo from Slayer\n";
+
+// Duck Hunter
+QUAK_HELPTEXT_1 = "  Shoot (choke: ";
+QUAK_HELPTEXT_2 = ")\n";
+QUAK_HELPTEXT_3 = "  Pump\n";
+QUAK_HELPTEXT_4 = "  Reload (side saddles first)\n";
+QUAK_HELPTEXT_5 = "  Reload (pockets only)\n";
+QUAK_HELPTEXT_6 = "  Load side saddles\n";
+
+// Dynamite
+DYNA_HELPTEXT_1 = "  Wind up, release to throw\n(\cxSTOP READING AND DO THIS";
+DYNA_HELPTEXT_2 = ")";
+DYNA_HELPTEXT_3 = "  Wind up, release to throw\n";
+DYNA_HELPTEXT_4 = "  Ready lighter, again to light fuse\n";
+DYNA_HELPTEXT_5 = "Abort/close lighter\n";
+DYNA_HELPTEXT_6 = "  Plant a bomb";
+
+// Explosive Hunter
+EHUN_HELPTEXT_1 = "  Shoot\n";
+EHUN_HELPTEXT_2 = "  Pump\n";
+EHUN_HELPTEXT_3 = "  Reload (side saddles first)\n";
+EHUN_HELPTEXT_4 = "  Reload (pockets only)\n";
+EHUN_HELPTEXT_5 = "  Pump/Semi";
+EHUN_HELPTEXT_6 = "/Auto";
+EHUN_HELPTEXT_7 = "  Load side saddles\n";
+
+// Flare Gun(s)
+FGUN_HELPTEXT_1 = "  Quick-Swap (if available)\n";
+FGUN_HELPTEXT_2 = "  Load flares\n";
+FGUN_HELPTEXT_3 = "  Load shells\n";
+FGUN_HELPTEXT_4 = "  Load slugs\n";
+FGUN_HELPTEXT_5 = "  Load explosive slugs\n";
+
+// FP-45 Liberator
+FP45_HELPTEXT_1 = "  Cock/Uncock hammer\n";
+FP45_HELPTEXT_2 = "  Quick-Swap (if available)\n\n";
+FP45_HELPTEXT_3 = "When hammer is uncocked...\n";
+FP45_HELPTEXT_4 = "  Refill spare rounds\n";
+FP45_HELPTEXT_5 = "  Remove a spare round\n";
+FP45_HELPTEXT_6 = "  Dump spare rounds\n\n";
+FP45_HELPTEXT_7 = "When hammer is cocked...\n";
+FP45_HELPTEXT_8 = "  Reload chamber (spare rounds first)\n";
+FP45_HELPTEXT_9 = "  Unload chamber\n";
+FP45_HELPTEXT_10 = "While emptying chamber...\n";
+FP45_HELPTEXT_11 = "(Hold)";
+FP45_HELPTEXT_12 = "  Speed reload";
+
+// Golden Single-Action Revolver
+GSAR_HELPTEXT_1 = " Close cylinder\n";
+GSAR_HELPTEXT_2 = " Cycle cylinder \(Hold ";
+GSAR_HELPTEXT_3 = " to reverse\)\n";
+GSAR_HELPTEXT_4 = " Hit extractor \n";
+GSAR_HELPTEXT_5 = " Load round \n";
+GSAR_HELPTEXT_6 = " Pull back hammer\n";
+GSAR_HELPTEXT_7 = "  Quick-Swap (if available)\n";
+GSAR_HELPTEXT_8 = " Open cylinder\n";
+
+// Hush Puppy
+HPUP_HELPTEXT_1 = "  Rack slide\n";
+HPUP_HELPTEXT_2 = "  Toggle slidelock\n";
+HPUP_HELPTEXT_3 = "  Quick-Swap (if available)\n";
+HPUP_HELPTEXT_4 = "  Reload mag\n";
+HPUP_HELPTEXT_5 = "  Reload chamber\n";
+HPUP_HELPTEXT_6 = "  Unload chamber\n";
+
+// Juan.
+JUAN_HELPTEXT_1 = "  Semi/Auto\n";
+JUAN_HELPTEXT_2 = "  Quick-Swap (if available)\n";
+JUAN_HELPTEXT_3 = "  Reload mag (horseshoe mags first)\n";
+JUAN_HELPTEXT_4 = "  Force standard mag reload\n";
+JUAN_HELPTEXT_5 = "  Reload chamber\n";
+
+// Less Lethal Hunter
+LLHN_HELPTEXT_1 = "  Shoot\n";
+LLHN_HELPTEXT_2 = "  Pump\n";
+LLHN_HELPTEXT_3 = "  Reload (side saddles first)\n";
+LLHN_HELPTEXT_4 = "  Reload (pockets only)\n";
+LLHN_HELPTEXT_5 = "  Load side saddles\n";
+
+// Micro Batteries
+MBAT_HELPTEXT_1 = "%s\c%s%s";
+MBAT_HELPTEXT_2 = "Charging: ";
+MBAT_HELPTEXT_3 = "\n\cu(\cqReload\cu to cycle)";
+
+MBAT_USERERROR_1 = "Battery configuration error: full battery selected. Rerouting.";
+MBAT_USERERROR_2 = "Battery configuration error: lowest battery selected. Rerouting.";
+
+// Minerva
+9LMG_HELPTEXT_1 = "  Reload mags\n";
+9LMG_HELPTEXT_2 = "  Reload battery\n";
+9LMG_HELPTEXT_3 = "  Switch to ";
+9LMG_HELPTEXT_4 = "700";
+9LMG_HELPTEXT_5 = "2100";
+9LMG_HELPTEXT_6 = " RPM\n";
+9LMG_HELPTEXT_7 = "  Zoom\n";
+9LMG_HELPTEXT_8 = "  Repair\n";
+9LMG_HELPTEXT_9 = "  or  ";
+9LMG_HELPTEXT_10 = "  Unload battery\n";
+
+// Obrez
+OBRZ_HELPTEXT_1 = "  Quick-swap(if available)\n";
+
+// Phazer
+PHZR_HELPTEXT_1 = "  Fire\n";
+PHZR_HELPTEXT_2 = "  Quick-swap (if available)\n";
+
+// Plasma Buster
+PBST_HELPTEXT_1 = "  Auto-fire\n";
+PBST_HELPTEXT_2 = "  Burst-fire\n";
+
+// PPSh-41
+PPSH_HELPTEXT_1 = "  Rack bolt\n";
+PPSH_HELPTEXT_2 = "  Semi/Auto\n";
+PPSH_HELPTEXT_3 = "  Reload mag (drum mags first)\n";
+PPSH_HELPTEXT_4 = "  Reload box magazine\n";
+
+// Savage Reloader
+SRLD_HELPTEXT_1 = "You reloaded ";
+SRLD_HELPTEXT_2 = " .300 Savage rounds during your downtime.";
+SRLD_HELPTEXT_3 = "  Assemble rounds\n";
+SRLD_HELPTEXT_4 = "  same";
+
+// Savage-99
+SLAR_HELPTEXT_1 = "  Work lever\n";
+SLAR_HELPTEXT_2 = "While holding ";
+SLAR_HELPTEXT_3 = "...\n";
+SLAR_HELPTEXT_4 = "  Reload chamber/magazine\n";
+SLAR_HELPTEXT_5 = "  Unload chamber/magazine/Clean rifle\n";
+SLAR_HELPTEXT_6 = "  Zoom\n";
+SLAR_HELPTEXT_7 = "  Bullet drop\n";
+
+// Single Action Revolver
+SARV_HELPTEXT_1 = " Close cylinder\n";
+SARV_HELPTEXT_2 = " Cycle cylinder \(Hold ";
+SARV_HELPTEXT_3 = " to reverse\)\n";
+SARV_HELPTEXT_4 = " Hit extractor \n";
+SARV_HELPTEXT_5 = " Load round \n";
+SARV_HELPTEXT_6 = " Pull back hammer\n";
+SARV_HELPTEXT_7 = "  Quick-Swap (if available)\n";
+SARV_HELPTEXT_8 = " Open cylinder\n";
+
+// Detective Special Revolver
+DSPR_HELPTEXT_1 = " Close cylinder\n";
+DSPR_HELPTEXT_2 = " Cycle cylinder \(Hold ";
+DSPR_HELPTEXT_3 = " to reverse\)\n";
+DSPR_HELPTEXT_4 = " Hit extractor \n";
+DSPR_HELPTEXT_5 = " Load round \n";
+DSPR_HELPTEXT_6 = " Pull back hammer\n";
+DSPR_HELPTEXT_7 = "  Quick-Swap (if available)\n";
+DSPR_HELPTEXT_8 = " Open cylinder\n";
+
+// STEN Gun
+STEN_HELPTEXT_1 = "  Open bolt/Clear jam\n";
+STEN_HELPTEXT_2 = "  Reload mag\n";
+STEN_HELPTEXT_3 = "  Semi/Auto\n";
+
+// Stun Gun
+STUN_HELPTEXT_1 = "  Zap\n";
+STUN_HELPTEXT_2 = "  Quick Prod\n";
+
+// Tokarev Reloader
+TRRL_HELPTEXT_1 = "You reloaded ";
+TRRL_HELPTEXT_2 = " 7.62 Tokarev rounds during your downtime, comrade.";
+TRRL_HELPTEXT_3 = "  Assemble 7.62 Tokarev rounds\n";
+TRRL_HELPTEXT_4 = "  same";
+
+// TT-33
+TT33_HELPTEXT_1 = "  Semi/Auto\n";
+TT33_HELPTEXT_2 = "  Rack slide\n";
+TT33_HELPTEXT_3 = "  Quick-Swap (if available)\n";
+TT33_HELPTEXT_4 = "  Reload mag\n";
+TT33_HELPTEXT_5 = "  Reload chamber\n";
+TT33_HELPTEXT_6 = "  Unload chamber/Clean pistol\n";
 
 // EVERYTHING below this is Menu stuff. Feast upon the horror. - [Ted]
 

--- a/zscript/10mm Weaponry/10mmautoreloader.zs
+++ b/zscript/10mm Weaponry/10mmautoreloader.zs
@@ -166,9 +166,10 @@ class TenMilAutoReloader:TenMilAutoReloadingThingy{
 		);
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
-		LWPHELP_FIRE.."  Assemble 10mm rounds\n"
-		..LWPHELP_USE.."+"..LWPHELP_UNLOAD.."  same"
+		LWPHELP_FIRE..Stringtable.Localize("$10RL_HELPTEXT_1")
+		..LWPHELP_USE.."+"..LWPHELP_UNLOAD..Stringtable.Localize("$10RL_HELPTEXT_2")
 		;
 	}
 	override bool AddSpareWeapon(actor newowner){return AddSpareWeaponRegular(newowner);}

--- a/zscript/10mm Weaponry/10mmautoreloader.zs
+++ b/zscript/10mm Weaponry/10mmautoreloader.zs
@@ -167,8 +167,8 @@ class TenMilAutoReloader:TenMilAutoReloadingThingy{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRE.."  Assemble 10mm rounds\n"
-		..WEPHELP_USE.."+"..WEPHELP_UNLOAD.."  same"
+		LWPHELP_FIRE.."  Assemble 10mm rounds\n"
+		..LWPHELP_USE.."+"..LWPHELP_UNLOAD.."  same"
 		;
 	}
 	override bool AddSpareWeapon(actor newowner){return AddSpareWeaponRegular(newowner);}

--- a/zscript/10mm Weaponry/wep_10mmPistol.zs
+++ b/zscript/10mm Weaponry/wep_10mmPistol.zs
@@ -82,13 +82,13 @@ class HD10mmPistol:HDHandgun{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRESHOOT
-		..((weaponstatus[0]&PISF_SELECTFIRE)?(WEPHELP_FIREMODE.."  Semi/Auto\n"):"")
-		..WEPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
-		..WEPHELP_RELOAD.."  Reload mag\n"
-		..WEPHELP_USE.."+"..WEPHELP_RELOAD.."  Reload chamber\n"
-		..WEPHELP_MAGMANAGER
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRESHOOT
+		..((weaponstatus[0]&PISF_SELECTFIRE)?(LWPHELP_FIREMODE.."  Semi/Auto\n"):"")
+		..LWPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
+		..LWPHELP_RELOAD.."  Reload mag\n"
+		..LWPHELP_USE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
+		..LWPHELP_MAGMANAGER
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/10mm Weaponry/wep_10mmPistol.zs
+++ b/zscript/10mm Weaponry/wep_10mmPistol.zs
@@ -81,12 +81,13 @@ class HD10mmPistol:HDHandgun{
 		if(hdw.weaponstatus[PISS_CHAMBER]==2)sb.drawrect(-19,-11,3,1);
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
 		LWPHELP_FIRESHOOT
-		..((weaponstatus[0]&PISF_SELECTFIRE)?(LWPHELP_FIREMODE.."  Semi/Auto\n"):"")
-		..LWPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
-		..LWPHELP_RELOAD.."  Reload mag\n"
-		..LWPHELP_USE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
+		..((weaponstatus[0]&PISF_SELECTFIRE)?(LWPHELP_FIREMODE..Stringtable.Localize("$10PS_HELPTEXT_1")):"")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$10PS_HELPTEXT_2")
+		..LWPHELP_RELOAD..Stringtable.Localize("$10PS_HELPTEXT_3")
+		..LWPHELP_USE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$10PS_HELPTEXT_4")
 		..LWPHELP_MAGMANAGER
 		..LWPHELP_UNLOADUNLOAD
 		;

--- a/zscript/10mm Weaponry/wep_sigcow.zs
+++ b/zscript/10mm Weaponry/wep_sigcow.zs
@@ -135,13 +135,13 @@ class HDSigCow:HDWeapon{
 
 	override string gethelptext(){
 		return  
-		WEPHELP_FIRESHOOT
-        ..WEPHELP_ALTFIRE.."  Bayonet Stab\n"
-		..WEPHELP_RELOAD.."  Reload mag\n"
-		..WEPHELP_USE.."+"..WEPHELP_RELOAD.."  Reload chamber\n"
-		..WEPHELP_FIREMODE.."  Semi/Burst/Auto\n"
-		..WEPHELP_MAGMANAGER
-		..WEPHELP_UNLOADUNLOAD  
+		LWPHELP_FIRESHOOT
+        ..LWPHELP_ALTFIRE.."  Bayonet Stab\n"
+		..LWPHELP_RELOAD.."  Reload mag\n"
+		..LWPHELP_USE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
+		..LWPHELP_FIREMODE.."  Semi/Burst/Auto\n"
+		..LWPHELP_MAGMANAGER
+		..LWPHELP_UNLOADUNLOAD  
 		;
 	}
 

--- a/zscript/10mm Weaponry/wep_sigcow.zs
+++ b/zscript/10mm Weaponry/wep_sigcow.zs
@@ -134,12 +134,13 @@ class HDSigCow:HDWeapon{
 	}
 
 	override string gethelptext(){
+		LocalizeHelp();
 		return  
 		LWPHELP_FIRESHOOT
-        ..LWPHELP_ALTFIRE.."  Bayonet Stab\n"
-		..LWPHELP_RELOAD.."  Reload mag\n"
-		..LWPHELP_USE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
-		..LWPHELP_FIREMODE.."  Semi/Burst/Auto\n"
+        ..LWPHELP_ALTFIRE..Stringtable.Localize("$SGCW_HELPTEXT_1")
+		..LWPHELP_RELOAD..Stringtable.Localize("$SGCW_HELPTEXT_2")
+		..LWPHELP_USE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$SGCW_HELPTEXT_3")
+		..LWPHELP_FIREMODE..Stringtable.Localize("$SGCW_HELPTEXT_4")
 		..LWPHELP_MAGMANAGER
 		..LWPHELP_UNLOADUNLOAD  
 		;

--- a/zscript/COP357/wep_cop357.zs
+++ b/zscript/COP357/wep_cop357.zs
@@ -123,14 +123,14 @@ class COP357Pistol:HDHandgun{
 	}
 	override string gethelptext(){
 		if(chamberopen)return
-		WEPHELP_FIRE.." Close cylinder\n"
-		..WEPHELP_UNLOAD.." Remove empty rounds \(double-tap to dump live rounds\)\n"
-		..WEPHELP_RELOAD.." Load round \(Hold "..WEPHELP_FIREMODE.." to force using 9mm\)\n"
+		LWPHELP_FIRE.." Close cylinder\n"
+		..LWPHELP_UNLOAD.." Remove empty rounds \(double-tap to dump live rounds\)\n"
+		..LWPHELP_RELOAD.." Load round \(Hold "..LWPHELP_FIREMODE.." to force using 9mm\)\n"
 		;
 		return
-		WEPHELP_FIRESHOOT
-		..WEPHELP_ALTRELOAD.."/"..WEPHELP_FIREMODE.."  Quick-Swap (if available)\n"
-		..WEPHELP_UNLOAD.."/"..WEPHELP_RELOAD.." Open chamber\n"
+		LWPHELP_FIRESHOOT
+		..LWPHELP_ALTRELOAD.."/"..LWPHELP_FIREMODE.."  Quick-Swap (if available)\n"
+		..LWPHELP_UNLOAD.."/"..LWPHELP_RELOAD.." Open chamber\n"
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/COP357/wep_cop357.zs
+++ b/zscript/COP357/wep_cop357.zs
@@ -18,21 +18,20 @@ class COP357Pistol:HDHandgun{
 		weapon.bobrangey 0.6;
 		weapon.bobspeed 2.5;
 		weapon.bobstyle "normal";
-		obituary "%o got COP'd by %k.";
-		tag "COP .357";
+		obituary "$OB_COP357";
+		tag "$TAG_COP357";
+		inventory.pickupmessage "$PICKUP_COP357";
 		hdweapon.refid HDLD_COP357;
 		hdweapon.barrelsize 12,0.5,0.7; //shorter and thicker than the revolver
 	
 	    hdweapon.loadoutcodes "
-			\quadshot - modifies pistol to shoot all barrels at once"
-			;
+			\cuquadshot - modifies pistol to shoot all 4 barrels at once";
 	}
 	
 	override string PickupMessage() {
-	    String pickupmessage = "You got the COP .357! What a bastard of a gun!"; 
-	    String quadshotmsg = " You got the COP .357! What a bastard of a gun! It feels a bit off...";
-	    if(weaponstatus[COPS_QUADSHOT]) return quadshotmsg;
-	    return pickupmessage;
+	    String msg = Super.PickupMessage();
+		if(weaponstatus[COPS_QUADSHOT]) return Stringtable.Localize("$PICKUP_COP357OFF");
+	    return msg;
 	}
 	
 	override void loadoutconfigure(string input){
@@ -122,15 +121,16 @@ class COP357Pistol:HDHandgun{
 	
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		if(chamberopen)return
-		LWPHELP_FIRE.." Close cylinder\n"
-		..LWPHELP_UNLOAD.." Remove empty rounds \(double-tap to dump live rounds\)\n"
-		..LWPHELP_RELOAD.." Load round \(Hold "..LWPHELP_FIREMODE.." to force using 9mm\)\n"
+		LWPHELP_FIRE..Stringtable.Localize("$C357_HELPTEXT_1")
+		..LWPHELP_UNLOAD..Stringtable.Localize("$C357_HELPTEXT_2")
+		..LWPHELP_RELOAD..Stringtable.Localize("$C357_HELPTEXT_3")..LWPHELP_FIREMODE..Stringtable.Localize("$C357_HELPTEXT_4")
 		;
 		return
 		LWPHELP_FIRESHOOT
-		..LWPHELP_ALTRELOAD.."/"..LWPHELP_FIREMODE.."  Quick-Swap (if available)\n"
-		..LWPHELP_UNLOAD.."/"..LWPHELP_RELOAD.." Open chamber\n"
+		..LWPHELP_ALTRELOAD.."/"..LWPHELP_FIREMODE..Stringtable.Localize("$C357_HELPTEXT_5")
+		..LWPHELP_UNLOAD.."/"..LWPHELP_RELOAD..Stringtable.Localize("$C357_HELPTEXT_6")
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Colt 1911/wep_Colt1911.zs
+++ b/zscript/Colt 1911/wep_Colt1911.zs
@@ -79,13 +79,13 @@ class HDColt1911:HDHandgun{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRESHOOT
-		..((weaponstatus[0]&PISF_SELECTFIRE)?(WEPHELP_FIREMODE.."  Semi/Auto\n"):"")
-		..WEPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
-		..WEPHELP_RELOAD.."  Reload mag\n"
-		..WEPHELP_USE.."+"..WEPHELP_RELOAD.."  Reload chamber\n"
-		..WEPHELP_MAGMANAGER
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRESHOOT
+		..((weaponstatus[0]&PISF_SELECTFIRE)?(LWPHELP_FIREMODE.."  Semi/Auto\n"):"")
+		..LWPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
+		..LWPHELP_RELOAD.."  Reload mag\n"
+		..LWPHELP_USE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
+		..LWPHELP_MAGMANAGER
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Colt 1911/wep_Colt1911.zs
+++ b/zscript/Colt 1911/wep_Colt1911.zs
@@ -78,12 +78,13 @@ class HDColt1911:HDHandgun{
 		if(hdw.weaponstatus[PISS_CHAMBER]==2)sb.drawrect(-19,-11,3,1);
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
 		LWPHELP_FIRESHOOT
-		..((weaponstatus[0]&PISF_SELECTFIRE)?(LWPHELP_FIREMODE.."  Semi/Auto\n"):"")
-		..LWPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
-		..LWPHELP_RELOAD.."  Reload mag\n"
-		..LWPHELP_USE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
+		..((weaponstatus[0]&PISF_SELECTFIRE)?(LWPHELP_FIREMODE..Stringtable.Localize("$1911_HELPTEXT_1")):"")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$1911_HELPTEXT_2")
+		..LWPHELP_RELOAD..Stringtable.Localize("$1911_HELPTEXT_3")
+		..LWPHELP_USE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$1911_HELPTEXT_4")
 		..LWPHELP_MAGMANAGER
 		..LWPHELP_UNLOADUNLOAD
 		;

--- a/zscript/Combat Shotgun/wep_combatshotgun.zs
+++ b/zscript/Combat Shotgun/wep_combatshotgun.zs
@@ -83,10 +83,11 @@ class HDCombatShotgun:HDShotgun{ //hope you're good at pumping ;)
 
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
-		LWPHELP_FIRE.."  Shoot\n"//no choke
-		..LWPHELP_ALTFIRE.."  Pump\n"
-		..LWPHELP_RELOAD.."  Reload\n"
+		LWPHELP_FIRE..Stringtable.Localize("$CBSG_HELPTEXT_1")//no choke
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$CBSG_HELPTEXT_2")
+		..LWPHELP_RELOAD..Stringtable.Localize("$CBSG_HELPTEXT_3")
 		..LWPHELP_UNLOADUNLOAD
 		;//no side saddles
 	}

--- a/zscript/Combat Shotgun/wep_combatshotgun.zs
+++ b/zscript/Combat Shotgun/wep_combatshotgun.zs
@@ -84,10 +84,10 @@ class HDCombatShotgun:HDShotgun{ //hope you're good at pumping ;)
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRE.."  Shoot\n"//no choke
-		..WEPHELP_ALTFIRE.."  Pump\n"
-		..WEPHELP_RELOAD.."  Reload\n"
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRE.."  Shoot\n"//no choke
+		..LWPHELP_ALTFIRE.."  Pump\n"
+		..LWPHELP_RELOAD.."  Reload\n"
+		..LWPHELP_UNLOADUNLOAD
 		;//no side saddles
 	}
 	override void DrawSightPicture(

--- a/zscript/Doomed Hunter/wep_doomhunter.zs
+++ b/zscript/Doomed Hunter/wep_doomhunter.zs
@@ -101,14 +101,15 @@ class DoomHunter:HDShotgun{
 	}
 
 	override string gethelptext(){
+		LocalizeHelp();
 		return
-		LWPHELP_FIRE.."  Shoot (choke: "..weaponstatus[DHUNS_CHOKE]..")\n"
-		..LWPHELP_ALTFIRE.."  Pump\n"
-		..LWPHELP_RELOAD.."  Reload (side saddles first)\n"
-		..LWPHELP_ALTRELOAD.."  Reload (pockets only)\n"
-		..(weaponstatus[0]&DHUNF_EXPORT?"":(LWPHELP_FIREMODE.."  Pump/Semi"..(weaponstatus[0]&DHUNF_CANFULLAUTO?"/Auto":"").."\n"))
-		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Load side saddles\n"
-		..LWPHELP_USE.."+"..LWPHELP_UNLOAD.."  Steal ammo from Slayer\n"
+		LWPHELP_FIRE..Stringtable.Localize("$DHUN_HELPTEXT_1")..weaponstatus[DHUNS_CHOKE]..Stringtable.Localize("$DHUN_HELPTEXT_2")
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$DHUN_HELPTEXT_3")
+		..LWPHELP_RELOAD..Stringtable.Localize("$DHUN_HELPTEXT_4")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$DHUN_HELPTEXT_5")
+		..(weaponstatus[0]&DHUNF_EXPORT?"":(LWPHELP_FIREMODE..Stringtable.Localize("$DHUN_HELPTEXT_6")..(weaponstatus[0]&DHUNF_CANFULLAUTO?Stringtable.Localize("$DHUN_HELPTEXT_7"):"").."\n"))
+		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$DHUN_HELPTEXT_8")
+		..LWPHELP_USE.."+"..LWPHELP_UNLOAD..Stringtable.Localize("$DHUN_HELPTEXT_9")
 		..LWPHELP_UNLOADUNLOAD
 		;
 	}

--- a/zscript/Doomed Hunter/wep_doomhunter.zs
+++ b/zscript/Doomed Hunter/wep_doomhunter.zs
@@ -102,14 +102,14 @@ class DoomHunter:HDShotgun{
 
 	override string gethelptext(){
 		return
-		WEPHELP_FIRE.."  Shoot (choke: "..weaponstatus[DHUNS_CHOKE]..")\n"
-		..WEPHELP_ALTFIRE.."  Pump\n"
-		..WEPHELP_RELOAD.."  Reload (side saddles first)\n"
-		..WEPHELP_ALTRELOAD.."  Reload (pockets only)\n"
-		..(weaponstatus[0]&DHUNF_EXPORT?"":(WEPHELP_FIREMODE.."  Pump/Semi"..(weaponstatus[0]&DHUNF_CANFULLAUTO?"/Auto":"").."\n"))
-		..WEPHELP_FIREMODE.."+"..WEPHELP_RELOAD.."  Load side saddles\n"
-		..WEPHELP_USE.."+"..WEPHELP_UNLOAD.."  Steal ammo from Slayer\n"
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRE.."  Shoot (choke: "..weaponstatus[DHUNS_CHOKE]..")\n"
+		..LWPHELP_ALTFIRE.."  Pump\n"
+		..LWPHELP_RELOAD.."  Reload (side saddles first)\n"
+		..LWPHELP_ALTRELOAD.."  Reload (pockets only)\n"
+		..(weaponstatus[0]&DHUNF_EXPORT?"":(LWPHELP_FIREMODE.."  Pump/Semi"..(weaponstatus[0]&DHUNF_CANFULLAUTO?"/Auto":"").."\n"))
+		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Load side saddles\n"
+		..LWPHELP_USE.."+"..LWPHELP_UNLOAD.."  Steal ammo from Slayer\n"
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 

--- a/zscript/Duck Hunter/wep_duckhunter.zs
+++ b/zscript/Duck Hunter/wep_duckhunter.zs
@@ -97,14 +97,13 @@ class DuckHunter:HDShotgun{
 		}
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
-		LWPHELP_FIRE.."  Shoot (choke: "..weaponstatus[DUCKHUNTS_CHOKE]..")\n"
-		..LWPHELP_ALTFIRE.."  Pump\n"
-		..LWPHELP_RELOAD.."  Reload (side saddles first)\n"
-		..LWPHELP_ALTRELOAD.."  Reload (pockets only)\n"
-	//	..(weaponstatus[0]&HUNTF_EXPORT?"":(LWPHELP_FIREMODE.."  Pump/Semi"..(weaponstatus[0]&HUNTF_CANFULLAUTO?"/Auto":"").."\n"))
-		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Load side saddles\n"
-	//	..LWPHELP_USE.."+"..LWPHELP_UNLOAD.."  Steal ammo from Slayer\n"
+		LWPHELP_FIRE..Stringtable.Localize("$QUAK_HELPTEXT_1")..weaponstatus[DUCKHUNTS_CHOKE]..Stringtable.Localize("$QUAK_HELPTEXT_2")
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$QUAK_HELPTEXT_3")
+		..LWPHELP_RELOAD..Stringtable.Localize("$QUAK_HELPTEXT_4")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$QUAK_HELPTEXT_5")
+		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$QUAK_HELPTEXT_6")
 		..LWPHELP_UNLOADUNLOAD
 		;
 	}

--- a/zscript/Duck Hunter/wep_duckhunter.zs
+++ b/zscript/Duck Hunter/wep_duckhunter.zs
@@ -98,14 +98,14 @@ class DuckHunter:HDShotgun{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRE.."  Shoot (choke: "..weaponstatus[DUCKHUNTS_CHOKE]..")\n"
-		..WEPHELP_ALTFIRE.."  Pump\n"
-		..WEPHELP_RELOAD.."  Reload (side saddles first)\n"
-		..WEPHELP_ALTRELOAD.."  Reload (pockets only)\n"
-	//	..(weaponstatus[0]&HUNTF_EXPORT?"":(WEPHELP_FIREMODE.."  Pump/Semi"..(weaponstatus[0]&HUNTF_CANFULLAUTO?"/Auto":"").."\n"))
-		..WEPHELP_FIREMODE.."+"..WEPHELP_RELOAD.."  Load side saddles\n"
-	//	..WEPHELP_USE.."+"..WEPHELP_UNLOAD.."  Steal ammo from Slayer\n"
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRE.."  Shoot (choke: "..weaponstatus[DUCKHUNTS_CHOKE]..")\n"
+		..LWPHELP_ALTFIRE.."  Pump\n"
+		..LWPHELP_RELOAD.."  Reload (side saddles first)\n"
+		..LWPHELP_ALTRELOAD.."  Reload (pockets only)\n"
+	//	..(weaponstatus[0]&HUNTF_EXPORT?"":(LWPHELP_FIREMODE.."  Pump/Semi"..(weaponstatus[0]&HUNTF_CANFULLAUTO?"/Auto":"").."\n"))
+		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Load side saddles\n"
+	//	..LWPHELP_USE.."+"..LWPHELP_UNLOAD.."  Steal ammo from Slayer\n"
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Dynamite/wep_dynamite.zs
+++ b/zscript/Dynamite/wep_dynamite.zs
@@ -82,13 +82,14 @@ class HDDynamiteThrower:HDWeapon{
 	}
 	
 	override string gethelptext(){
+		LocalizeHelp();
 		if(weaponstatus[0]&DYNAF_SPOONOFF)return
-		LWPHELP_FIRE.."  Wind up, release to throw\n(\cxSTOP READING AND DO THIS"..WEPHELP_RGCOL..")";
+		LWPHELP_FIRE..Stringtable.Localize("$DYNA_HELPTEXT_1")..WEPHELP_RGCOL..Stringtable.Localize("$DYNA_HELPTEXT_2");
 		return
-		LWPHELP_FIRE.."  Wind up, release to throw\n"
-		..LWPHELP_ALTFIRE.."  Ready lighter, again to light fuse\n"
-		..LWPHELP_RELOAD.."  Abort/close lighter\n"
-		..LWPHELP_FIREMODE.."  Plant a bomb"
+		LWPHELP_FIRE..Stringtable.Localize("$DYNA_HELPTEXT_3")
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$DYNA_HELPTEXT_4")
+		..LWPHELP_RELOAD..Stringtable.Localize("$DYNA_HELPTEXT_5")
+		..LWPHELP_FIREMODE..Stringtable.Localize("$DYNA_HELPTEXT_6")
 		;
 	}
 	
@@ -895,7 +896,7 @@ class HDDynamiteRollerUnlit:HDUPK{//the projectile after it hits the ground
 		
 		hdupk.amount 1;
 		hdupk.pickuptype "HDDynamiteAmmo";
-		hdupk.pickupmessage "Picked up a bundle of dynamite.";
+		hdupk.pickupmessage "$PICKUP_DYNAMITE";
 		hdupk.pickupsound "weapons/rifleclick2";
 		stamina 1;
 		
@@ -907,7 +908,7 @@ class HDDynamiteRollerUnlit:HDUPK{//the projectile after it hits the ground
 		height 8;
 		damagetype "none";
 		scale 0.3;
-		obituary "%o was blown to smitheteens by %k.";
+		obituary "$OB_DYNAMITE";
 		radiusdamagefactor 0.04;
 		pushfactor 1.4;
 		maxstepheight 2;
@@ -1082,7 +1083,7 @@ class DynaP:HDUPK{
 		scale 0.3;height 3;radius 3;
 		hdupk.amount 1;
 		hdupk.pickuptype "HDDynamiteAmmo";
-		hdupk.pickupmessage "Picked up a bundle of dynamite.";
+		hdupk.pickupmessage "$PICKUP_DYNAMITE";
 		hdupk.pickupsound "weapons/rifleclick2";
 		stamina 1;
 	}

--- a/zscript/Dynamite/wep_dynamite.zs
+++ b/zscript/Dynamite/wep_dynamite.zs
@@ -83,12 +83,12 @@ class HDDynamiteThrower:HDWeapon{
 	
 	override string gethelptext(){
 		if(weaponstatus[0]&DYNAF_SPOONOFF)return
-		WEPHELP_FIRE.."  Wind up, release to throw\n(\cxSTOP READING AND DO THIS"..WEPHELP_RGCOL..")";
+		LWPHELP_FIRE.."  Wind up, release to throw\n(\cxSTOP READING AND DO THIS"..WEPHELP_RGCOL..")";
 		return
-		WEPHELP_FIRE.."  Wind up, release to throw\n"
-		..WEPHELP_ALTFIRE.."  Ready lighter, again to light fuse\n"
-		..WEPHELP_RELOAD.."  Abort/close lighter\n"
-		..WEPHELP_FIREMODE.."  Plant a bomb"
+		LWPHELP_FIRE.."  Wind up, release to throw\n"
+		..LWPHELP_ALTFIRE.."  Ready lighter, again to light fuse\n"
+		..LWPHELP_RELOAD.."  Abort/close lighter\n"
+		..LWPHELP_FIREMODE.."  Plant a bomb"
 		;
 	}
 	

--- a/zscript/Explosive Shotgun/wep_explosiveHunter.zs
+++ b/zscript/Explosive Shotgun/wep_explosiveHunter.zs
@@ -108,13 +108,13 @@ override void failedpickupunload(){
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRE.."  Shoot\n"
-		..WEPHELP_ALTFIRE.."  Pump\n"
-		..WEPHELP_RELOAD.."  Reload (side saddles first)\n"
-		..WEPHELP_ALTRELOAD.."  Reload (pockets only)\n"
-		..(weaponstatus[0]&EXHUNTF_EXPORT?"":(WEPHELP_FIREMODE.."  Pump/Semi"..(weaponstatus[0]&EXHUNTF_CANFULLAUTO?"/Auto":"").."\n"))
-		..WEPHELP_FIREMODE.."+"..WEPHELP_RELOAD.."  Load side saddles\n"
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRE.."  Shoot\n"
+		..LWPHELP_ALTFIRE.."  Pump\n"
+		..LWPHELP_RELOAD.."  Reload (side saddles first)\n"
+		..LWPHELP_ALTRELOAD.."  Reload (pockets only)\n"
+		..(weaponstatus[0]&EXHUNTF_EXPORT?"":(LWPHELP_FIREMODE.."  Pump/Semi"..(weaponstatus[0]&EXHUNTF_CANFULLAUTO?"/Auto":"").."\n"))
+		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Load side saddles\n"
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Explosive Shotgun/wep_explosiveHunter.zs
+++ b/zscript/Explosive Shotgun/wep_explosiveHunter.zs
@@ -107,13 +107,14 @@ override void failedpickupunload(){
 		}
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
-		LWPHELP_FIRE.."  Shoot\n"
-		..LWPHELP_ALTFIRE.."  Pump\n"
-		..LWPHELP_RELOAD.."  Reload (side saddles first)\n"
-		..LWPHELP_ALTRELOAD.."  Reload (pockets only)\n"
-		..(weaponstatus[0]&EXHUNTF_EXPORT?"":(LWPHELP_FIREMODE.."  Pump/Semi"..(weaponstatus[0]&EXHUNTF_CANFULLAUTO?"/Auto":"").."\n"))
-		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Load side saddles\n"
+		LWPHELP_FIRE..Stringtable.Localize("$EHUN_HELPTEXT_1")
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$EHUN_HELPTEXT_2")
+		..LWPHELP_RELOAD..Stringtable.Localize("$EHUN_HELPTEXT_3")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$EHUN_HELPTEXT_4")
+		..(weaponstatus[0]&EXHUNTF_EXPORT?"":(LWPHELP_FIREMODE..Stringtable.Localize("$EHUN_HELPTEXT_5")..(weaponstatus[0]&EXHUNTF_CANFULLAUTO?Stringtable.Localize("$EHUN_HELPTEXT_6"):"").."\n"))
+		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$EHUN_HELPTEXT_7")
 		..LWPHELP_UNLOADUNLOAD
 		;
 	}

--- a/zscript/Explosive Shotgun/wep_explosiveshotguns.zs
+++ b/zscript/Explosive Shotgun/wep_explosiveshotguns.zs
@@ -6,8 +6,8 @@ class HDShotgunExplosive:HDWeapon{
 		weapon.bobrangex 0.21;
 		weapon.bobrangey 0.86;
 		scale 0.6;
-		inventory.pickupmessage "You got a shotgun!";
-		obituary "%o got %h the hot bullets of %k's shotgun to die.";
+		inventory.pickupmessage "$PICKUP_ESHOTGUN";
+		obituary "$OB_ESHOTGUN";
 	}
 	override bool AddSpareWeapon(actor newowner){return AddSpareWeaponRegular(newowner);}
 	override hdweapon GetSpareWeapon(actor newowner,bool reverse,bool doselect){return GetSpareWeaponRegular(newowner,reverse,doselect);}
@@ -55,22 +55,7 @@ class HDShotgunExplosive:HDWeapon{
 		A_StartSound("weapons/pocket",9);
 		ExEmptyHand(uamt);
 	}
-/*
-	action void A_CannibalizeOtherExplosiveShotgun(){
-		let hhh=hdweapon(findinventory(invoker is "ExplosiveHunter"?"ExplosiveSlayer":"Hunter"));
-		if(hhh){
-			int totake=min(
-				hhh.weaponstatus[EXSHOTS_SIDESADDLE],
-				HDPickup.MaxGive(self,"HDExplosiveShellAmmo",ENC_SHELL),
-				4
-			);
-			if(totake>0){
-				hhh.weaponstatus[EXSHOTS_SIDESADDLE]-=totake;
-				A_GiveInventory("HDExplosiveShellAmmo",totake);
-			}
-		}
-	}
-*/
+
 	//not all loads are equal
 	double shotpower;
 	static double getshotpower(){return frandom(0.9,1.05);}

--- a/zscript/FP-45 Liberator/wep_fp45.zs
+++ b/zscript/FP-45 Liberator/wep_fp45.zs
@@ -62,19 +62,20 @@ class HDFP45:HDHandgun{
 		}
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
-		LWPHELP_ALTFIRE.."  Cock/Uncock hammer\n"
-		..LWPHELP_ALTRELOAD.."  Quick-Swap (if available)\n\n"
-		.."When hammer is uncocked...\n"
-		.."  "..LWPHELP_RELOAD.."  Refill spare rounds\n"
-		.."  "..LWPHELP_UNLOAD.."  Remove a spare round\n"
-	    .."  "..LWPHELP_USE.." + "..LWPHELP_UNLOAD.."  Dump spare rounds\n\n"
-		.."When hammer is cocked...\n"
+		LWPHELP_ALTFIRE..Stringtable.Localize("$FP45_HELPTEXT_1")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$FP45_HELPTEXT_2")
+		..Stringtable.Localize("$FP45_HELPTEXT_3")
+		.."  "..LWPHELP_RELOAD..Stringtable.Localize("$FP45_HELPTEXT_4")
+		.."  "..LWPHELP_UNLOAD..Stringtable.Localize("$FP45_HELPTEXT_5")
+	    .."  "..LWPHELP_USE.." + "..LWPHELP_UNLOAD..Stringtable.Localize("$FP45_HELPTEXT_6")
+		..Stringtable.Localize("$FP45_HELPTEXT_7")
 		.."  "..LWPHELP_FIRESHOOT
-		.."  "..LWPHELP_RELOAD.."  Reload chamber (spare rounds first)\n"
-		.."  "..LWPHELP_UNLOAD.."  Unload chamber\n"
-		.."While emptying chamber...\n"
-		.."  "..LWPHELP_RELOAD.."(Hold)".."  Speed reload" 
+		.."  "..LWPHELP_RELOAD..Stringtable.Localize("$FP45_HELPTEXT_8")
+		.."  "..LWPHELP_UNLOAD..Stringtable.Localize("$FP45_HELPTEXT_9")
+		..Stringtable.Localize("$FP45_HELPTEXT_10")
+		.."  "..LWPHELP_RELOAD..Stringtable.Localize("$FP45_HELPTEXT_11")..Stringtable.Localize("$FP45_HELPTEXT_12") 
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/FP-45 Liberator/wep_fp45.zs
+++ b/zscript/FP-45 Liberator/wep_fp45.zs
@@ -63,18 +63,18 @@ class HDFP45:HDHandgun{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_ALTFIRE.."  Cock/Uncock hammer\n"
-		..WEPHELP_ALTRELOAD.."  Quick-Swap (if available)\n\n"
+		LWPHELP_ALTFIRE.."  Cock/Uncock hammer\n"
+		..LWPHELP_ALTRELOAD.."  Quick-Swap (if available)\n\n"
 		.."When hammer is uncocked...\n"
-		.."  "..WEPHELP_RELOAD.."  Refill spare rounds\n"
-		.."  "..WEPHELP_UNLOAD.."  Remove a spare round\n"
-	    .."  "..WEPHELP_USE.." + "..WEPHELP_UNLOAD.."  Dump spare rounds\n\n"
+		.."  "..LWPHELP_RELOAD.."  Refill spare rounds\n"
+		.."  "..LWPHELP_UNLOAD.."  Remove a spare round\n"
+	    .."  "..LWPHELP_USE.." + "..LWPHELP_UNLOAD.."  Dump spare rounds\n\n"
 		.."When hammer is cocked...\n"
-		.."  "..WEPHELP_FIRESHOOT
-		.."  "..WEPHELP_RELOAD.."  Reload chamber (spare rounds first)\n"
-		.."  "..WEPHELP_UNLOAD.."  Unload chamber\n"
+		.."  "..LWPHELP_FIRESHOOT
+		.."  "..LWPHELP_RELOAD.."  Reload chamber (spare rounds first)\n"
+		.."  "..LWPHELP_UNLOAD.."  Unload chamber\n"
 		.."While emptying chamber...\n"
-		.."  "..WEPHELP_RELOAD.."(Hold)".."  Speed reload" 
+		.."  "..LWPHELP_RELOAD.."(Hold)".."  Speed reload" 
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Flare Guns/wep_hdflaregun.zs
+++ b/zscript/Flare Guns/wep_hdflaregun.zs
@@ -199,13 +199,13 @@ action void A_CheckFlareGunHand(bool filled)
 	override string gethelptext()
 	{
 		return
-		WEPHELP_FIRESHOOT
-		..WEPHELP_ALTFIRE..", "..WEPHELP_FIREMODE.."  Quick-Swap (if available)\n"
-		..WEPHELP_RELOAD.."  Load flares\n"
-		..WEPHELP_ALTRELOAD.."  Load shells\n"
-		..WEPHELP_FIREMODE.."+"..WEPHELP_RELOAD.."  Load slugs\n"
-		..WEPHELP_FIREMODE.."+"..WEPHELP_ALTRELOAD.."  Load explosive slugs\n"
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRESHOOT
+		..LWPHELP_ALTFIRE..", "..LWPHELP_FIREMODE.."  Quick-Swap (if available)\n"
+		..LWPHELP_RELOAD.."  Load flares\n"
+		..LWPHELP_ALTRELOAD.."  Load shells\n"
+		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Load slugs\n"
+		..LWPHELP_FIREMODE.."+"..LWPHELP_ALTRELOAD.."  Load explosive slugs\n"
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	

--- a/zscript/Flare Guns/wep_hdflaregun.zs
+++ b/zscript/Flare Guns/wep_hdflaregun.zs
@@ -198,13 +198,14 @@ action void A_CheckFlareGunHand(bool filled)
 	
 	override string gethelptext()
 	{
+		LocalizeHelp();
 		return
 		LWPHELP_FIRESHOOT
-		..LWPHELP_ALTFIRE..", "..LWPHELP_FIREMODE.."  Quick-Swap (if available)\n"
-		..LWPHELP_RELOAD.."  Load flares\n"
-		..LWPHELP_ALTRELOAD.."  Load shells\n"
-		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Load slugs\n"
-		..LWPHELP_FIREMODE.."+"..LWPHELP_ALTRELOAD.."  Load explosive slugs\n"
+		..LWPHELP_ALTFIRE..", "..LWPHELP_FIREMODE..Stringtable.Localize("$FGUN_HELPTEXT_1")
+		..LWPHELP_RELOAD..Stringtable.Localize("$FGUN_HELPTEXT_2")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$FGUN_HELPTEXT_3")
+		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$FGUN_HELPTEXT_4")
+		..LWPHELP_FIREMODE.."+"..LWPHELP_ALTRELOAD..Stringtable.Localize("$FGUN_HELPTEXT_5")
 		..LWPHELP_UNLOADUNLOAD
 		;
 	}

--- a/zscript/Flare Guns/wep_hdmetalflaregun.zs
+++ b/zscript/Flare Guns/wep_hdmetalflaregun.zs
@@ -130,13 +130,14 @@ action void A_CheckMetalFlareGunHand(bool filled)
 	
 	override string gethelptext()
 	{
+		LocalizeHelp();
 		return
 		LWPHELP_FIRESHOOT
-		..LWPHELP_ALTFIRE.."  Quick-Swap (if available)\n"
-		..LWPHELP_RELOAD.."  Load flares\n"
-		..LWPHELP_ALTRELOAD.."  Load shells\n"
-		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Load slugs\n"
-		..LWPHELP_FIREMODE.."+"..LWPHELP_ALTRELOAD.."  Load explosive slugs\n"
+		..LWPHELP_ALTFIRE..", "..LWPHELP_FIREMODE..Stringtable.Localize("$FGUN_HELPTEXT_1")
+		..LWPHELP_RELOAD..Stringtable.Localize("$FGUN_HELPTEXT_2")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$FGUN_HELPTEXT_3")
+		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$FGUN_HELPTEXT_4")
+		..LWPHELP_FIREMODE.."+"..LWPHELP_ALTRELOAD..Stringtable.Localize("$FGUN_HELPTEXT_5")
 		..LWPHELP_UNLOADUNLOAD
 		;
 	}

--- a/zscript/Flare Guns/wep_hdmetalflaregun.zs
+++ b/zscript/Flare Guns/wep_hdmetalflaregun.zs
@@ -131,13 +131,13 @@ action void A_CheckMetalFlareGunHand(bool filled)
 	override string gethelptext()
 	{
 		return
-		WEPHELP_FIRESHOOT
-		..WEPHELP_ALTFIRE.."  Quick-Swap (if available)\n"
-		..WEPHELP_RELOAD.."  Load flares\n"
-		..WEPHELP_ALTRELOAD.."  Load shells\n"
-		..WEPHELP_FIREMODE.."+"..WEPHELP_RELOAD.."  Load slugs\n"
-		..WEPHELP_FIREMODE.."+"..WEPHELP_ALTRELOAD.."  Load explosive slugs\n"
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRESHOOT
+		..LWPHELP_ALTFIRE.."  Quick-Swap (if available)\n"
+		..LWPHELP_RELOAD.."  Load flares\n"
+		..LWPHELP_ALTRELOAD.."  Load shells\n"
+		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Load slugs\n"
+		..LWPHELP_FIREMODE.."+"..LWPHELP_ALTRELOAD.."  Load explosive slugs\n"
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	

--- a/zscript/FragCannon/wep_fragcannon.zs
+++ b/zscript/FragCannon/wep_fragcannon.zs
@@ -46,6 +46,7 @@ class FragCannon:HDWeapon{
 		);
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
 		LWPHELP_FIRESHOOT
 		..LWPHELP_RELOADRELOAD

--- a/zscript/FragCannon/wep_fragcannon.zs
+++ b/zscript/FragCannon/wep_fragcannon.zs
@@ -47,9 +47,9 @@ class FragCannon:HDWeapon{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRESHOOT
-		..WEPHELP_RELOADRELOAD
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRESHOOT
+		..LWPHELP_RELOADRELOAD
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Golden Gun/wep_GoldSArevolver.zs
+++ b/zscript/Golden Gun/wep_GoldSArevolver.zs
@@ -94,16 +94,16 @@ if(ninemil>0){
 
 	override string gethelptext(){
 		if(cylinderopen)return
-		WEPHELP_FIRE.." Close cylinder\n"
-		..WEPHELP_ALTFIRE.." Cycle cylinder \(Hold "..WEPHELP_ZOOM.." to reverse\)\n"
-		..WEPHELP_UNLOAD.." Hit extractor \n"
-		..WEPHELP_RELOAD.." Load round \n"
+		LWPHELP_FIRE.." Close cylinder\n"
+		..LWPHELP_ALTFIRE.." Cycle cylinder \(Hold "..LWPHELP_ZOOM.." to reverse\)\n"
+		..LWPHELP_UNLOAD.." Hit extractor \n"
+		..LWPHELP_RELOAD.." Load round \n"
 		;
 		return
-		WEPHELP_FIRESHOOT
-		..WEPHELP_ALTFIRE.." Pull back hammer\n"
-		..WEPHELP_ALTRELOAD.."/"..WEPHELP_FIREMODE.."  Quick-Swap (if available)\n"
-		..WEPHELP_UNLOAD.."/"..WEPHELP_RELOAD.." Open cylinder\n"
+		LWPHELP_FIRESHOOT
+		..LWPHELP_ALTFIRE.." Pull back hammer\n"
+		..LWPHELP_ALTRELOAD.."/"..LWPHELP_FIREMODE.."  Quick-Swap (if available)\n"
+		..LWPHELP_UNLOAD.."/"..LWPHELP_RELOAD.." Open cylinder\n"
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Golden Gun/wep_GoldSArevolver.zs
+++ b/zscript/Golden Gun/wep_GoldSArevolver.zs
@@ -50,12 +50,6 @@ class HDGoldSingleActionRevolver:HDHandgun{
 			sb.drawimage("GC45A0",(-47,-10),sb.DI_SCREEN_CENTER_BOTTOM,scale:(1,1));
 			sb.drawnum(hpl.countinv("HDGold45LCAmmo"),-44,-8,sb.DI_SCREEN_CENTER_BOTTOM);
 			int ninemil=hpl.countinv("HDGold45LCAmmo");
-/*			
-if(ninemil>0){
-				sb.drawimage("PRNDA0",(-64,-10),sb.DI_SCREEN_CENTER_BOTTOM,scale:(2.1,2.1));
-				sb.drawnum(ninemil,-60,-8,sb.DI_SCREEN_CENTER_BOTTOM);
-			}
-*/
 		}
 		int plf=hpl.player.getpsprite(PSP_WEAPON).frame;
 		for(int i=GSAS_CYL1;i<=GSAS_CYL6;i++){
@@ -93,17 +87,18 @@ if(ninemil>0){
 	}
 
 	override string gethelptext(){
+		LocalizeHelp();
 		if(cylinderopen)return
-		LWPHELP_FIRE.." Close cylinder\n"
-		..LWPHELP_ALTFIRE.." Cycle cylinder \(Hold "..LWPHELP_ZOOM.." to reverse\)\n"
-		..LWPHELP_UNLOAD.." Hit extractor \n"
-		..LWPHELP_RELOAD.." Load round \n"
+		LWPHELP_FIRE..Stringtable.Localize("$GSAR_HELPTEXT_1")
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$GSAR_HELPTEXT_2")..LWPHELP_ZOOM..Stringtable.Localize("$GSAR_HELPTEXT_3")
+		..LWPHELP_UNLOAD..Stringtable.Localize("$GSAR_HELPTEXT_4")
+		..LWPHELP_RELOAD..Stringtable.Localize("$GSAR_HELPTEXT_5")
 		;
 		return
 		LWPHELP_FIRESHOOT
-		..LWPHELP_ALTFIRE.." Pull back hammer\n"
-		..LWPHELP_ALTRELOAD.."/"..LWPHELP_FIREMODE.."  Quick-Swap (if available)\n"
-		..LWPHELP_UNLOAD.."/"..LWPHELP_RELOAD.." Open cylinder\n"
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$GSAR_HELPTEXT_6")
+		..LWPHELP_ALTRELOAD.."/"..LWPHELP_FIREMODE..Stringtable.Localize("$GSAR_HELPTEXT_7")
+		..LWPHELP_UNLOAD.."/"..LWPHELP_RELOAD..Stringtable.Localize("$GSAR_HELPTEXT_8")
 		;
 	}
 	override void DrawSightPicture(
@@ -137,7 +132,6 @@ if(ninemil>0){
 		if(owner){
 			amt=clamp(amt,6,12);
 			if(owner.countinv("HDGold45LCAmmo"))owner.A_DropInventory("HDGold45LCAmmo",amt);
-			//else owner.A_DropInventory("HDPistolAmmo",amt);
 		}
 	}
 	override void ForceBasicAmmo(){
@@ -198,7 +192,6 @@ if(ninemil>0){
 			player.cmd.buttons&BT_FIREMODE
 			||!countinv("HDGold45LCAmmo")
 		);
-		//if(useninemil&&!countinv("HDPistolAmmo"))return;
 		class<inventory>ammotype=useninemil?"HDGold45LCAmmo":"HDGold45LCAmmo";
 		A_TakeInventory(ammotype,1,TIF_NOTAKEINFINITE);
 		invoker.weaponstatus[GSAS_CYL1]=useninemil?GSAS_NINEMIL:GSAS_MASTERBALL;
@@ -533,9 +526,6 @@ if(ninemil>0){
 		}goto nope;
 	open_dumpcylinder:
 		GSAG F 1 A_HitExtractor();
-/*
-  GSAG G 4 A_RotateCylinder(pressingzoom());//works like reloading
-*/
 		goto readyopen;
 	open_dumpcylinder_all:
 		GSAG F 1 offset(0,34);

--- a/zscript/Hacked ZM66/wep_hackedzm66.zs
+++ b/zscript/Hacked ZM66/wep_hackedzm66.zs
@@ -129,19 +129,20 @@ class HackedZM66AssaultRifle:ZM66ScopeHaver{
 		);
 	}
 	override string gethelptext(){
-		bool gl=!(weaponstatus[0]&ZM66HACKEDF_NOLAUNCHER);
-		bool glmode=gl&&(weaponstatus[0]&ZM66HACKEDF_GLMODE);
+		bool gl=!(weaponstatus[0]&ZM66F_NOLAUNCHER);
+		bool glmode=gl&&(weaponstatus[0]&ZM66F_GLMODE);
+		LocalizeHelp();
 		return
 		LWPHELP_FIRESHOOT
-		..(gl?(LWPHELP_ALTFIRE..(glmode?("  Rifle mode\n"):("  GL mode\n"))):"")
-		..LWPHELP_RELOAD.."  Reload mag\n"
-		..(gl?(LWPHELP_ALTRELOAD.."  Reload GL\n"):"")
-		..(glmode?(LWPHELP_FIREMODE.."+"..LWPHELP_UPDOWN.."  Airburst\n")
+		..(gl?(LWPHELP_ALTFIRE..(glmode?(StringTable.Localize("$ZMWH_ALTFIRE1")):(StringTable.Localize("$ZMWH_ALTFIRE2")))):"")
+		..LWPHELP_RELOAD..StringTable.Localize("$ZMWH_RELOAD")
+		..(gl?(LWPHELP_ALTRELOAD..StringTable.Localize("$ZMWH_ALTRELOAD")):"")
+		..(glmode?(LWPHELP_FIREMODE.."+"..LWPHELP_UPDOWN..StringTable.Localize("$ZMWH_FMODPUD"))
 			:(
-			((weaponstatus[0]&ZM66HACKEDF_NOFIRESELECT)?"":LWPHELP_FIREMODE.."  Semi/Auto/Burst\n")
-			..LWPHELP_ZOOM.."+"..LWPHELP_FIREMODE.."+"..LWPHELP_UPDOWN.."  Zoom\n"))
+			((weaponstatus[0]&ZM66F_NOFIRESELECT)?"":LWPHELP_FIREMODE..StringTable.Localize("$ZMWH_FMODE"))
+			..LWPHELP_ZOOM.."+"..LWPHELP_FIREMODE.."+"..LWPHELP_UPDOWN..StringTable.Localize("$ZMWH_ZPFMOD")))
 		..LWPHELP_MAGMANAGER
-		..LWPHELP_UNLOAD.."  Unload "..(glmode?"GL":"magazine")
+		..LWPHELP_UNLOAD..StringTable.Localize("$ZMWH_UNLOAD")..(glmode?StringTable.Localize("$ZMWH_GL"):StringTable.Localize("$ZMWH_MAG"))
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Hacked ZM66/wep_hackedzm66.zs
+++ b/zscript/Hacked ZM66/wep_hackedzm66.zs
@@ -132,16 +132,16 @@ class HackedZM66AssaultRifle:ZM66ScopeHaver{
 		bool gl=!(weaponstatus[0]&ZM66HACKEDF_NOLAUNCHER);
 		bool glmode=gl&&(weaponstatus[0]&ZM66HACKEDF_GLMODE);
 		return
-		WEPHELP_FIRESHOOT
-		..(gl?(WEPHELP_ALTFIRE..(glmode?("  Rifle mode\n"):("  GL mode\n"))):"")
-		..WEPHELP_RELOAD.."  Reload mag\n"
-		..(gl?(WEPHELP_ALTRELOAD.."  Reload GL\n"):"")
-		..(glmode?(WEPHELP_FIREMODE.."+"..WEPHELP_UPDOWN.."  Airburst\n")
+		LWPHELP_FIRESHOOT
+		..(gl?(LWPHELP_ALTFIRE..(glmode?("  Rifle mode\n"):("  GL mode\n"))):"")
+		..LWPHELP_RELOAD.."  Reload mag\n"
+		..(gl?(LWPHELP_ALTRELOAD.."  Reload GL\n"):"")
+		..(glmode?(LWPHELP_FIREMODE.."+"..LWPHELP_UPDOWN.."  Airburst\n")
 			:(
-			((weaponstatus[0]&ZM66HACKEDF_NOFIRESELECT)?"":WEPHELP_FIREMODE.."  Semi/Auto/Burst\n")
-			..WEPHELP_ZOOM.."+"..WEPHELP_FIREMODE.."+"..WEPHELP_UPDOWN.."  Zoom\n"))
-		..WEPHELP_MAGMANAGER
-		..WEPHELP_UNLOAD.."  Unload "..(glmode?"GL":"magazine")
+			((weaponstatus[0]&ZM66HACKEDF_NOFIRESELECT)?"":LWPHELP_FIREMODE.."  Semi/Auto/Burst\n")
+			..LWPHELP_ZOOM.."+"..LWPHELP_FIREMODE.."+"..LWPHELP_UPDOWN.."  Zoom\n"))
+		..LWPHELP_MAGMANAGER
+		..LWPHELP_UNLOAD.."  Unload "..(glmode?"GL":"magazine")
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/HushPuppy/wep_hushpuppy.zs
+++ b/zscript/HushPuppy/wep_hushpuppy.zs
@@ -71,15 +71,15 @@ class HushpuppyPistol:HDHandgun{
 	
 	override string gethelptext(){
 		return
-		WEPHELP_FIRESHOOT
-	    ..WEPHELP_ALTFIRE.."  Rack slide\n"
-	    ..WEPHELP_FIREMODE.."  Toggle slidelock\n"
-		..WEPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
-		..WEPHELP_RELOAD.."  Reload mag\n"
-		..WEPHELP_ALTFIRE.."+"..WEPHELP_RELOAD.."  Reload chamber\n"
-		..WEPHELP_ALTFIRE.."+"..WEPHELP_UNLOAD.."  Unload chamber\n"
-		..WEPHELP_MAGMANAGER
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRESHOOT
+	    ..LWPHELP_ALTFIRE.."  Rack slide\n"
+	    ..LWPHELP_FIREMODE.."  Toggle slidelock\n"
+		..LWPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
+		..LWPHELP_RELOAD.."  Reload mag\n"
+		..LWPHELP_ALTFIRE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
+		..LWPHELP_ALTFIRE.."+"..LWPHELP_UNLOAD.."  Unload chamber\n"
+		..LWPHELP_MAGMANAGER
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	

--- a/zscript/HushPuppy/wep_hushpuppy.zs
+++ b/zscript/HushPuppy/wep_hushpuppy.zs
@@ -70,17 +70,17 @@ class HushpuppyPistol:HDHandgun{
 	}
 	
 	override string gethelptext(){
+		LocalizeHelp();
 		return
 		LWPHELP_FIRESHOOT
-	    ..LWPHELP_ALTFIRE.."  Rack slide\n"
-	    ..LWPHELP_FIREMODE.."  Toggle slidelock\n"
-		..LWPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
-		..LWPHELP_RELOAD.."  Reload mag\n"
-		..LWPHELP_ALTFIRE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
-		..LWPHELP_ALTFIRE.."+"..LWPHELP_UNLOAD.."  Unload chamber\n"
+	    ..LWPHELP_ALTFIRE..Stringtable.Localize("$HPUP_HELPTEXT_1")
+	    ..LWPHELP_FIREMODE..Stringtable.Localize("$HPUP_HELPTEXT_2")
+		..LWPHELP_ALTRELOAD..StringTable.Localize("$HPUP_HELPTEXT_3")
+		..LWPHELP_RELOAD..Stringtable.Localize("$HPUP_HELPTEXT_4")
+		..LWPHELP_ALTFIRE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$HPUP_HELPTEXT_5")
+		..LWPHELP_ALTFIRE.."+"..LWPHELP_UNLOAD..Stringtable.Localize("$HPUP_HELPTEXT_6")
 		..LWPHELP_MAGMANAGER
-		..LWPHELP_UNLOADUNLOAD
-		;
+		..LWPHELP_UNLOADUNLOAD;
 	}
 	
 	override void DrawSightPicture(

--- a/zscript/Juan 9mm Pistol/wep_juan.zs
+++ b/zscript/Juan 9mm Pistol/wep_juan.zs
@@ -188,13 +188,14 @@ class HDHorseshoePistol:HDHandgun{
 		if(hdw.weaponstatus[HPISS_CHAMBER]==2)sb.drawrect(-19,-11,3,1);
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
 		LWPHELP_FIRESHOOT
-		..((weaponstatus[0]&HPISF_SELECTFIRE)?(LWPHELP_FIREMODE.."  Semi/Auto\n"):"")
-		..LWPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
-		..LWPHELP_RELOAD.."  Reload mag (horseshoe mags first)\n"
-		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Force standard mag reload\n"
-		..LWPHELP_USE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
+		..((weaponstatus[0]&HPISF_SELECTFIRE)?(LWPHELP_FIREMODE..Stringtable.Localize("$JUAN_HELPTEXT_1")):"")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$JUAN_HELPTEXT_2")
+		..LWPHELP_RELOAD..Stringtable.Localize("$JUAN_HELPTEXT_3")
+		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$JUAN_HELPTEXT_4")
+		..LWPHELP_USE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$JUAN_HELPTEXT_5")
 		..LWPHELP_MAGMANAGER
 		..LWPHELP_UNLOADUNLOAD
 		;

--- a/zscript/Juan 9mm Pistol/wep_juan.zs
+++ b/zscript/Juan 9mm Pistol/wep_juan.zs
@@ -189,14 +189,14 @@ class HDHorseshoePistol:HDHandgun{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRESHOOT
-		..((weaponstatus[0]&HPISF_SELECTFIRE)?(WEPHELP_FIREMODE.."  Semi/Auto\n"):"")
-		..WEPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
-		..WEPHELP_RELOAD.."  Reload mag (horseshoe mags first)\n"
-		..WEPHELP_FIREMODE.."+"..WEPHELP_RELOAD.."  Force standard mag reload\n"
-		..WEPHELP_USE.."+"..WEPHELP_RELOAD.."  Reload chamber\n"
-		..WEPHELP_MAGMANAGER
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRESHOOT
+		..((weaponstatus[0]&HPISF_SELECTFIRE)?(LWPHELP_FIREMODE.."  Semi/Auto\n"):"")
+		..LWPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
+		..LWPHELP_RELOAD.."  Reload mag (horseshoe mags first)\n"
+		..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Force standard mag reload\n"
+		..LWPHELP_USE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
+		..LWPHELP_MAGMANAGER
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Less Lethal Hunter/wep_LLhunter.zs
+++ b/zscript/Less Lethal Hunter/wep_LLhunter.zs
@@ -83,14 +83,14 @@ class LLHunter:HDLLShotgun{
 		}
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
-		LWPHELP_FIRE.."  Shoot\n"
-		..LWPHELP_ALTFIRE.."  Pump\n"
-		..LWPHELP_RELOAD.."  Reload (side saddles first)\n"
-		..LWPHELP_ALTRELOAD.."  Reload (pockets only)\n"
-                ..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Load side saddles\n"
-	        ..LWPHELP_UNLOADUNLOAD
-		;
+		LWPHELP_FIRE..Stringtable.Localize("$LLHN_HELPTEXT_1")
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$LLHN_HELPTEXT_2")
+		..LWPHELP_RELOAD..Stringtable.Localize("$LLHN_HELPTEXT_3")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$LLHN_HELPTEXT_4")
+        ..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$LLHN_HELPTEXT_5")
+	    ..LWPHELP_UNLOADUNLOAD;
 	}
 	override void DrawSightPicture(
 		HDStatusBar sb,HDWeapon hdw,HDPlayerPawn hpl,

--- a/zscript/Less Lethal Hunter/wep_LLhunter.zs
+++ b/zscript/Less Lethal Hunter/wep_LLhunter.zs
@@ -84,12 +84,12 @@ class LLHunter:HDLLShotgun{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRE.."  Shoot\n"
-		..WEPHELP_ALTFIRE.."  Pump\n"
-		..WEPHELP_RELOAD.."  Reload (side saddles first)\n"
-		..WEPHELP_ALTRELOAD.."  Reload (pockets only)\n"
-                ..WEPHELP_FIREMODE.."+"..WEPHELP_RELOAD.."  Load side saddles\n"
-	        ..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRE.."  Shoot\n"
+		..LWPHELP_ALTFIRE.."  Pump\n"
+		..LWPHELP_RELOAD.."  Reload (side saddles first)\n"
+		..LWPHELP_ALTRELOAD.."  Reload (pockets only)\n"
+                ..LWPHELP_FIREMODE.."+"..LWPHELP_RELOAD.."  Load side saddles\n"
+	        ..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/MicroCell/ammo_microcell.zs
+++ b/zscript/MicroCell/ammo_microcell.zs
@@ -107,12 +107,12 @@ class HDMicroCell:HDMagAmmo{
 		){
 			if(chargemode==BATT_CHARGESELECTED){
 				if(biggestamt>=10){
-					owner.A_Log("Battery configuration error: full battery selected. Rerouting.",true);
+					owner.A_Log(Stringtable.Localize("$MBAT_USERERROR_1"),true);
 				}else if(
 					biggestindex==smallestindex
 					&&biggestindex==maxindex
 				){
-					owner.A_Log("Battery configuration error: lowest battery selected. Rerouting.",true);
+					owner.A_Log(Stringtable.Localize("$MBAT_USERERROR_2"),true);
 				}
 				chargemode=BATT_CHARGEMAX;
 			}
@@ -153,7 +153,7 @@ class HDMicroCell:HDMagAmmo{
 		if(battt==hdbattery.BATT_CHARGEMAX)batts="eAuto";
 		else if(battt==hdbattery.BATT_CHARGESELECTED)batts="ySelected";
 		sb.DrawString(
-			sb.psmallfont,string.format("%s\c%s%s",helptext?"Charging: ":"",batts,helptext?"\n\cu(\cqReload\cu to cycle)":""),(offx+2,offy),
+			sb.psmallfont,string.format(Stringtable.Localize("$MBAT_HELPTEXT_1"),helptext?Stringtable.Localize("$MBAT_HELPTEXT_2"):"",batts,helptext?Stringtable.Localize("$MBAT_HELPTEXT_3"):""),(offx+2,offy),
 			sb.DI_SCREEN_CENTER|sb.DI_TEXT_ALIGN_LEFT,
 			wrapwidth:smallfont.StringWidth("m")*80
 		);

--- a/zscript/Minerva/wep_minerva.zs
+++ b/zscript/Minerva/wep_minerva.zs
@@ -177,15 +177,15 @@ override void postbeginplay(){
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRESHOOT
-		..WEPHELP_RELOAD.."  Reload mags\n"
-		..WEPHELP_ALTRELOAD.."  Reload battery\n"
-		..WEPHELP_FIREMODE.."  Switch to "..(weaponstatus[0]&MNVF_FAST?"700":"2100").." RPM\n"
-		..WEPHELP_ZOOM.."+"..WEPHELP_FIREMODE.."+"..WEPHELP_UPDOWN.."  Zoom\n"
-		..WEPHELP_ZOOM.."+"..WEPHELP_UNLOAD.."  Repair\n"
-		..WEPHELP_MAGMANAGER
-		..WEPHELP_UNLOADUNLOAD
-		..WEPHELP_USE.."+"..WEPHELP_UNLOAD.."  or  "..WEPHELP_USE.."+"..WEPHELP_ALTRELOAD.."  Unload battery\n"
+		LWPHELP_FIRESHOOT
+		..LWPHELP_RELOAD.."  Reload mags\n"
+		..LWPHELP_ALTRELOAD.."  Reload battery\n"
+		..LWPHELP_FIREMODE.."  Switch to "..(weaponstatus[0]&MNVF_FAST?"700":"2100").." RPM\n"
+		..LWPHELP_ZOOM.."+"..LWPHELP_FIREMODE.."+"..LWPHELP_UPDOWN.."  Zoom\n"
+		..LWPHELP_ZOOM.."+"..LWPHELP_UNLOAD.."  Repair\n"
+		..LWPHELP_MAGMANAGER
+		..LWPHELP_UNLOADUNLOAD
+		..LWPHELP_USE.."+"..LWPHELP_UNLOAD.."  or  "..LWPHELP_USE.."+"..LWPHELP_ALTRELOAD.."  Unload battery\n"
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Minerva/wep_minerva.zs
+++ b/zscript/Minerva/wep_minerva.zs
@@ -176,16 +176,17 @@ override void postbeginplay(){
 		);
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
 		LWPHELP_FIRESHOOT
-		..LWPHELP_RELOAD.."  Reload mags\n"
-		..LWPHELP_ALTRELOAD.."  Reload battery\n"
-		..LWPHELP_FIREMODE.."  Switch to "..(weaponstatus[0]&MNVF_FAST?"700":"2100").." RPM\n"
-		..LWPHELP_ZOOM.."+"..LWPHELP_FIREMODE.."+"..LWPHELP_UPDOWN.."  Zoom\n"
-		..LWPHELP_ZOOM.."+"..LWPHELP_UNLOAD.."  Repair\n"
+		..LWPHELP_RELOAD..Stringtable.Localize("$9LMG_HELPTEXT_1")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$9LMG_HELPTEXT_2")
+		..LWPHELP_FIREMODE..Stringtable.Localize("$9LMG_HELPTEXT_3")..(weaponstatus[0]&MNVF_FAST?Stringtable.Localize("$9LMG_HELPTEXT_4"):Stringtable.Localize("$9LMG_HELPTEXT_5"))..Stringtable.Localize("$9LMG_HELPTEXT_6")
+		..LWPHELP_ZOOM.."+"..LWPHELP_FIREMODE.."+"..LWPHELP_UPDOWN..Stringtable.Localize("$9LMG_HELPTEXT_7")
+		..LWPHELP_ZOOM.."+"..LWPHELP_UNLOAD..Stringtable.Localize("$9LMG_HELPTEXT_8")
 		..LWPHELP_MAGMANAGER
 		..LWPHELP_UNLOADUNLOAD
-		..LWPHELP_USE.."+"..LWPHELP_UNLOAD.."  or  "..LWPHELP_USE.."+"..LWPHELP_ALTRELOAD.."  Unload battery\n"
+		..LWPHELP_USE.."+"..LWPHELP_UNLOAD..Stringtable.Localize("$9LMG_HELPTEXT_9")..LWPHELP_USE.."+"..LWPHELP_ALTRELOAD..Stringtable.Localize("$9LMG_HELPTEXT_10")
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Obrozz Pistol/wep_obrozzpistol.zs
+++ b/zscript/Obrozz Pistol/wep_obrozzpistol.zs
@@ -159,16 +159,17 @@ action void A_CheckRifleHand()
 		);
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
 		LWPHELP_FIRESHOOT
-                ..LWPHELP_FIREMODE.."  Quick-swap(if available)\n"
-		..LWPHELP_ALTFIRE.."  Work bolt\n"
-		..LWPHELP_RELOAD.."  Reload rounds/clip\n"
-		..LWPHELP_ZOOM.."+"..LWPHELP_FIREMODE.."  Zoom\n"
-		..LWPHELP_ZOOM.."+"..LWPHELP_USE.."  Bullet drop\n"
-		..LWPHELP_ZOOM.."+"..LWPHELP_DROPONE.."  Force drop non-recast\n"
-		..LWPHELP_ZOOM.."+"..LWPHELP_ALTRELOAD.."  Force load recast\n"
-		..LWPHELP_ALTFIRE.."+"..LWPHELP_UNLOAD.."  Unload chamber/Clean rifle\n"
+		..LWPHELP_FIREMODE..Stringtable.Localize("$OBRZ_HELPTEXT_1")
+		..LWPHELP_ALTFIRE..StringTable.Localize("$BOSWH_ALTFIRE")
+		..LWPHELP_RELOAD..StringTable.Localize("$BOSWH_RELOAD")
+		..LWPHELP_ZOOM.."+"..LWPHELP_FIREMODE..StringTable.Localize("$BOSWH_ZPFMOD")
+		..LWPHELP_ZOOM.."+"..LWPHELP_USE..StringTable.Localize("$BOSWH_ZPUSE")
+		..LWPHELP_ZOOM.."+"..LWPHELP_DROPONE..StringTable.Localize("$BOSWH_ZPDRON")
+		..LWPHELP_ZOOM.."+"..LWPHELP_ALTRELOAD..StringTable.Localize("$BOSWH_ZPALTRELOAD")
+		..LWPHELP_ALTFIRE.."+"..LWPHELP_UNLOAD..StringTable.Localize("$BOSWH_AFIREPUNL")
 		..LWPHELP_UNLOADUNLOAD
 		;
 	}

--- a/zscript/Obrozz Pistol/wep_obrozzpistol.zs
+++ b/zscript/Obrozz Pistol/wep_obrozzpistol.zs
@@ -160,16 +160,16 @@ action void A_CheckRifleHand()
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRESHOOT
-                ..WEPHELP_FIREMODE.."  Quick-swap(if available)\n"
-		..WEPHELP_ALTFIRE.."  Work bolt\n"
-		..WEPHELP_RELOAD.."  Reload rounds/clip\n"
-		..WEPHELP_ZOOM.."+"..WEPHELP_FIREMODE.."  Zoom\n"
-		..WEPHELP_ZOOM.."+"..WEPHELP_USE.."  Bullet drop\n"
-		..WEPHELP_ZOOM.."+"..WEPHELP_DROPONE.."  Force drop non-recast\n"
-		..WEPHELP_ZOOM.."+"..WEPHELP_ALTRELOAD.."  Force load recast\n"
-		..WEPHELP_ALTFIRE.."+"..WEPHELP_UNLOAD.."  Unload chamber/Clean rifle\n"
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRESHOOT
+                ..LWPHELP_FIREMODE.."  Quick-swap(if available)\n"
+		..LWPHELP_ALTFIRE.."  Work bolt\n"
+		..LWPHELP_RELOAD.."  Reload rounds/clip\n"
+		..LWPHELP_ZOOM.."+"..LWPHELP_FIREMODE.."  Zoom\n"
+		..LWPHELP_ZOOM.."+"..LWPHELP_USE.."  Bullet drop\n"
+		..LWPHELP_ZOOM.."+"..LWPHELP_DROPONE.."  Force drop non-recast\n"
+		..LWPHELP_ZOOM.."+"..LWPHELP_ALTRELOAD.."  Force load recast\n"
+		..LWPHELP_ALTFIRE.."+"..LWPHELP_UNLOAD.."  Unload chamber/Clean rifle\n"
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 

--- a/zscript/PPSh-41/mag_ppsh41.zs
+++ b/zscript/PPSh-41/mag_ppsh41.zs
@@ -17,7 +17,6 @@ class HDTokarevMag71:HDMagAmmo{
 		hdmagammo.roundbulk ENC_762TOKAREV_LOADED;
 		hdmagammo.magbulk ENC_TOKAREV_DRUM_EMPTY;
 		tag "$TAG_PPSH41MAG71";
-//		inventory.pickupmessage "Picked up a PPSh-41 drum magazine.";
 		hdpickup.refid "tm7";
 	}
     

--- a/zscript/PPSh-41/wep_ppsh41.zs
+++ b/zscript/PPSh-41/wep_ppsh41.zs
@@ -149,13 +149,13 @@ class HDPPSh41 :HDWeapon{//this shouldn't inherit from HDHandgun, that was an ov
 	
 	override string gethelptext(){
 		return
-		WEPHELP_FIRESHOOT
-		..WEPHELP_ALTFIRE.."  Rack bolt\n"
-		..WEPHELP_FIREMODE.."  Semi/Auto\n"
-		..WEPHELP_RELOAD.."  Reload mag (drum mags first)\n"
-		..WEPHELP_ALTRELOAD.."  Reload box magazine\n"
-		..WEPHELP_MAGMANAGER
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRESHOOT
+		..LWPHELP_ALTFIRE.."  Rack bolt\n"
+		..LWPHELP_FIREMODE.."  Semi/Auto\n"
+		..LWPHELP_RELOAD.."  Reload mag (drum mags first)\n"
+		..LWPHELP_ALTRELOAD.."  Reload box magazine\n"
+		..LWPHELP_MAGMANAGER
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	

--- a/zscript/PPSh-41/wep_ppsh41.zs
+++ b/zscript/PPSh-41/wep_ppsh41.zs
@@ -20,13 +20,13 @@ class HDPPSh41 :HDWeapon{//this shouldn't inherit from HDHandgun, that was an ov
 		tag "$TAG_PPSH41";
 		hdweapon.refid "pps";
 		hdweapon.barrelsize 30,0.3,0.4;
-    inventory.icon "PS41C0";
+	    inventory.icon "PS41C0";
 
-		hdweapon.loadoutcodes "
 		//switchtype config unused, afaik all 
 		//Soviet-era PPSh-41s had full-auto
+		hdweapon.loadoutcodes "
 			\cufiremode - 0/1, semi/auto
-			\box - start loaded with a box magazine instead"
+			\cubox - start loaded with a box magazine instead"
 			;
 	}
 
@@ -150,10 +150,10 @@ class HDPPSh41 :HDWeapon{//this shouldn't inherit from HDHandgun, that was an ov
 	override string gethelptext(){
 		return
 		LWPHELP_FIRESHOOT
-		..LWPHELP_ALTFIRE.."  Rack bolt\n"
-		..LWPHELP_FIREMODE.."  Semi/Auto\n"
-		..LWPHELP_RELOAD.."  Reload mag (drum mags first)\n"
-		..LWPHELP_ALTRELOAD.."  Reload box magazine\n"
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$PPSH_HELPTEXT_1")
+		..LWPHELP_FIREMODE..Stringtable.Localize("$PPSH_HELPTEXT_2")
+		..LWPHELP_RELOAD..Stringtable.Localize("$PPSH_HELPTEXT_3")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$PPSH_HELPTEXT_4")
 		..LWPHELP_MAGMANAGER
 		..LWPHELP_UNLOADUNLOAD
 		;

--- a/zscript/Phazer/wep_phazerpistol.zs
+++ b/zscript/Phazer/wep_phazerpistol.zs
@@ -88,8 +88,8 @@ class PhazerPistol:HDHandgun{
 
 	override string gethelptext(){
 		return
-		  LWPHELP_FIRE.."  Fire\n"
-		..LWPHELP_FIREMODE.."  Quick-swap (if available)\n"
+		  LWPHELP_FIRE..Stringtable.Localize("$PHZR_HELPTEXT_1")
+		..LWPHELP_FIREMODE..Stringtable.Localize("$PHZR_HELPTEXT_2")
 		..LWPHELP_RELOADRELOAD
 		..LWPHELP_UNLOADUNLOAD
 		;

--- a/zscript/Phazer/wep_phazerpistol.zs
+++ b/zscript/Phazer/wep_phazerpistol.zs
@@ -88,10 +88,10 @@ class PhazerPistol:HDHandgun{
 
 	override string gethelptext(){
 		return
-		  WEPHELP_FIRE.."  Fire\n"
-		..WEPHELP_FIREMODE.."  Quick-swap (if available)\n"
-		..WEPHELP_RELOADRELOAD
-		..WEPHELP_UNLOADUNLOAD
+		  LWPHELP_FIRE.."  Fire\n"
+		..LWPHELP_FIREMODE.."  Quick-swap (if available)\n"
+		..LWPHELP_RELOADRELOAD
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 

--- a/zscript/Plasma Buster/wep_plasmabuster.zs
+++ b/zscript/Plasma Buster/wep_plasmabuster.zs
@@ -166,10 +166,10 @@ class PlasmaBuster:HDCellWeapon{
 
 	override string gethelptext(){
 		return
-		  WEPHELP_FIRE.."  Auto-fire\n"
-   ..WEPHELP_ALTFIRE.."  Burst-fire\n"
-		..WEPHELP_RELOADRELOAD
-		..WEPHELP_UNLOADUNLOAD
+		  LWPHELP_FIRE.."  Auto-fire\n"
+   ..LWPHELP_ALTFIRE.."  Burst-fire\n"
+		..LWPHELP_RELOADRELOAD
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 

--- a/zscript/Plasma Buster/wep_plasmabuster.zs
+++ b/zscript/Plasma Buster/wep_plasmabuster.zs
@@ -166,8 +166,8 @@ class PlasmaBuster:HDCellWeapon{
 
 	override string gethelptext(){
 		return
-		  LWPHELP_FIRE.."  Auto-fire\n"
-   ..LWPHELP_ALTFIRE.."  Burst-fire\n"
+		LWPHELP_FIRE..Stringtable.Localize("$PBST_HELPTEXT_1")
+   		..LWPHELP_ALTFIRE..Stringtable.Localize("$PBST_HELPTEXT_2")
 		..LWPHELP_RELOADRELOAD
 		..LWPHELP_UNLOADUNLOAD
 		;

--- a/zscript/STEN/wep_stenmk2s.zs
+++ b/zscript/STEN/wep_stenmk2s.zs
@@ -91,13 +91,13 @@ class HDStenMk2:HDWeapon{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRESHOOT
-		..WEPHELP_ALTFIRE.."  Open bolt/Clear jam\n"
-		..WEPHELP_RELOAD.."  Reload mag\n"
-		//..WEPHELP_USE.."+"..WEPHELP_RELOAD.."  Reload chamber\n"
-		..WEPHELP_FIREMODE.."  Semi/Auto\n"
-		..WEPHELP_MAGMANAGER
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRESHOOT
+		..LWPHELP_ALTFIRE.."  Open bolt/Clear jam\n"
+		..LWPHELP_RELOAD.."  Reload mag\n"
+		//..LWPHELP_USE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
+		..LWPHELP_FIREMODE.."  Semi/Auto\n"
+		..LWPHELP_MAGMANAGER
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/STEN/wep_stenmk2s.zs
+++ b/zscript/STEN/wep_stenmk2s.zs
@@ -12,7 +12,7 @@ class HDStenMk2:HDWeapon{
 		//$Sprite "STENA0"
 
 		+hdweapon.fitsinbackpack
-		obituary "%o was silenced by %k's STEN gun.";
+		obituary "$OB_STENGUN";
 		weapon.selectionorder 24;
 		weapon.slotnumber 2;
 		weapon.slotpriority 0.9;
@@ -92,10 +92,9 @@ class HDStenMk2:HDWeapon{
 	override string gethelptext(){
 		return
 		LWPHELP_FIRESHOOT
-		..LWPHELP_ALTFIRE.."  Open bolt/Clear jam\n"
-		..LWPHELP_RELOAD.."  Reload mag\n"
-		//..LWPHELP_USE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
-		..LWPHELP_FIREMODE.."  Semi/Auto\n"
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$STEN_HELPTEXT_1")
+		..LWPHELP_RELOAD..Stringtable.Localize("$STEN_HELPTEXT_2")
+		..LWPHELP_FIREMODE..Stringtable.Localize("$STEN_HELPTEXT_3")
 		..LWPHELP_MAGMANAGER
 		..LWPHELP_UNLOADUNLOAD
 		;

--- a/zscript/Savage 99/item_savagereloader.zs
+++ b/zscript/Savage 99/item_savagereloader.zs
@@ -161,8 +161,8 @@ class SavageAutoReloader:SavageAutoReloadingThingy{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRE.."  Assemble rounds\n"
-		..WEPHELP_USE.."+"..WEPHELP_UNLOAD.."  same"
+		LWPHELP_FIRE.."  Assemble rounds\n"
+		..LWPHELP_USE.."+"..LWPHELP_UNLOAD.."  same"
 		;
 	}
 	override bool AddSpareWeapon(actor newowner){return AddSpareWeaponRegular(newowner);}

--- a/zscript/Savage 99/item_savagereloader.zs
+++ b/zscript/Savage 99/item_savagereloader.zs
@@ -51,9 +51,9 @@ class SavageAutoReloadingThingy:HDWeapon{
 		if(onpadd>0)owner.A_GiveInventory("Savage300Ammo",onpadd);
 
 
-		owner.A_Log("You reloaded "..didmake.." .300 Savage rounds during your downtime.",true);
+		owner.A_Log(Stringtable.Localize("$SRLD_HELPTEXT_1")..didmake..Stringtable.Localize("$SRLD_HELPTEXT_2"),true);
 	}
-	
+
 	override void actualpickup(actor other,bool silent){
 		super.actualpickup(other,silent);
 		if(!other)return;
@@ -161,8 +161,8 @@ class SavageAutoReloader:SavageAutoReloadingThingy{
 	}
 	override string gethelptext(){
 		return
-		LWPHELP_FIRE.."  Assemble rounds\n"
-		..LWPHELP_USE.."+"..LWPHELP_UNLOAD.."  same"
+		LWPHELP_FIRE..Stringtable.Localize("$SRLD_HELPTEXT_3")
+		..LWPHELP_USE.."+"..LWPHELP_UNLOAD..Stringtable.Localize("$SRLD_HELPTEXT_4")
 		;
 	}
 	override bool AddSpareWeapon(actor newowner){return AddSpareWeaponRegular(newowner);}

--- a/zscript/Savage 99/wep_savage99rifle.zs
+++ b/zscript/Savage 99/wep_savage99rifle.zs
@@ -119,13 +119,13 @@ class Savage99SniperRifle:HDWeapon{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRESHOOT
-		..WEPHELP_ALTFIRE.."  Work lever\n"
-		.."While holding "..WEPHELP_ALTFIRE.."...\n"
-		.."  +"..WEPHELP_RELOAD.."  Reload chamber/magazine\n"
-		.."  +"..WEPHELP_UNLOAD.."  Unload chamber/magazine/Clean rifle\n"
-		..WEPHELP_ZOOM.."+"..WEPHELP_FIREMODE.."  Zoom\n"
-		..WEPHELP_ZOOM.."+"..WEPHELP_USE.."  Bullet drop\n"
+		LWPHELP_FIRESHOOT
+		..LWPHELP_ALTFIRE.."  Work lever\n"
+		.."While holding "..LWPHELP_ALTFIRE.."...\n"
+		.."  +"..LWPHELP_RELOAD.."  Reload chamber/magazine\n"
+		.."  +"..LWPHELP_UNLOAD.."  Unload chamber/magazine/Clean rifle\n"
+		..LWPHELP_ZOOM.."+"..LWPHELP_FIREMODE.."  Zoom\n"
+		..LWPHELP_ZOOM.."+"..LWPHELP_USE.."  Bullet drop\n"
 	;
 	}
 	override void DrawSightPicture(

--- a/zscript/Savage 99/wep_savage99rifle.zs
+++ b/zscript/Savage 99/wep_savage99rifle.zs
@@ -118,14 +118,15 @@ class Savage99SniperRifle:HDWeapon{
 
 	}
 	override string gethelptext(){
+		LocalizeHelp();
 		return
 		LWPHELP_FIRESHOOT
-		..LWPHELP_ALTFIRE.."  Work lever\n"
-		.."While holding "..LWPHELP_ALTFIRE.."...\n"
-		.."  +"..LWPHELP_RELOAD.."  Reload chamber/magazine\n"
-		.."  +"..LWPHELP_UNLOAD.."  Unload chamber/magazine/Clean rifle\n"
-		..LWPHELP_ZOOM.."+"..LWPHELP_FIREMODE.."  Zoom\n"
-		..LWPHELP_ZOOM.."+"..LWPHELP_USE.."  Bullet drop\n"
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$SLAR_HELPTEXT_1")
+		..Stringtable.Localize("$SLAR_HELPTEXT_2")..LWPHELP_ALTFIRE..Stringtable.Localize("$SLAR_HELPTEXT_3")
+		.."  +"..LWPHELP_RELOAD..Stringtable.Localize("$SLAR_HELPTEXT_4")
+		.."  +"..LWPHELP_UNLOAD..Stringtable.Localize("$SLAR_HELPTEXT_5")
+		..LWPHELP_ZOOM.."+"..LWPHELP_FIREMODE..Stringtable.Localize("$SLAR_HELPTEXT_6")
+		..LWPHELP_ZOOM.."+"..LWPHELP_USE..Stringtable.Localize("$SLAR_HELPTEXT_7")
 	;
 	}
 	override void DrawSightPicture(

--- a/zscript/Single Action Revolver/wep_SArevolver.zs
+++ b/zscript/Single Action Revolver/wep_SArevolver.zs
@@ -95,17 +95,18 @@ if(ninemil>0){
 	}
 
 	override string gethelptext(){
+		LocalizeHelp();
 		if(cylinderopen)return
-		LWPHELP_FIRE.." Close cylinder\n"
-		..LWPHELP_ALTFIRE.." Cycle cylinder \(Hold "..LWPHELP_ZOOM.." to reverse\)\n"
-		..LWPHELP_UNLOAD.." Hit extractor \n"
-		..LWPHELP_RELOAD.." Load round \n"
+		LWPHELP_FIRE..Stringtable.Localize("$SARV_HELPTEXT_1")
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$SARV_HELPTEXT_2")..LWPHELP_ZOOM..Stringtable.Localize("$SARV_HELPTEXT_3")
+		..LWPHELP_UNLOAD..Stringtable.Localize("$SARV_HELPTEXT_4")
+		..LWPHELP_RELOAD..Stringtable.Localize("$SARV_HELPTEXT_5")
 		;
 		return
 		LWPHELP_FIRESHOOT
-		..LWPHELP_ALTFIRE.." Pull back hammer\n"
-		..LWPHELP_ALTRELOAD.."/"..LWPHELP_FIREMODE.."  Quick-Swap (if available)\n"
-		..LWPHELP_UNLOAD.."/"..LWPHELP_RELOAD.." Open cylinder\n"
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$SARV_HELPTEXT_6")
+		..LWPHELP_ALTRELOAD.."/"..LWPHELP_FIREMODE..Stringtable.Localize("$SARV_HELPTEXT_7")
+		..LWPHELP_UNLOAD.."/"..LWPHELP_RELOAD..Stringtable.Localize("$SARV_HELPTEXT_8")
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Single Action Revolver/wep_SArevolver.zs
+++ b/zscript/Single Action Revolver/wep_SArevolver.zs
@@ -96,16 +96,16 @@ if(ninemil>0){
 
 	override string gethelptext(){
 		if(cylinderopen)return
-		WEPHELP_FIRE.." Close cylinder\n"
-		..WEPHELP_ALTFIRE.." Cycle cylinder \(Hold "..WEPHELP_ZOOM.." to reverse\)\n"
-		..WEPHELP_UNLOAD.." Hit extractor \n"
-		..WEPHELP_RELOAD.." Load round \n"
+		LWPHELP_FIRE.." Close cylinder\n"
+		..LWPHELP_ALTFIRE.." Cycle cylinder \(Hold "..LWPHELP_ZOOM.." to reverse\)\n"
+		..LWPHELP_UNLOAD.." Hit extractor \n"
+		..LWPHELP_RELOAD.." Load round \n"
 		;
 		return
-		WEPHELP_FIRESHOOT
-		..WEPHELP_ALTFIRE.." Pull back hammer\n"
-		..WEPHELP_ALTRELOAD.."/"..WEPHELP_FIREMODE.."  Quick-Swap (if available)\n"
-		..WEPHELP_UNLOAD.."/"..WEPHELP_RELOAD.." Open cylinder\n"
+		LWPHELP_FIRESHOOT
+		..LWPHELP_ALTFIRE.." Pull back hammer\n"
+		..LWPHELP_ALTRELOAD.."/"..LWPHELP_FIREMODE.."  Quick-Swap (if available)\n"
+		..LWPHELP_UNLOAD.."/"..LWPHELP_RELOAD.." Open cylinder\n"
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/Snubnose Revolver/wep_snubnose.zs
+++ b/zscript/Snubnose Revolver/wep_snubnose.zs
@@ -99,16 +99,16 @@ class HDSnubNoseRevolver:HDHandgun{
 	}
 	override string gethelptext(){
 		if(cylinderopen)return
-		WEPHELP_FIRE.." Close cylinder\n"
-		..WEPHELP_ALTFIRE.." Cycle cylinder \(Hold "..WEPHELP_ZOOM.." to reverse\)\n"
-		..WEPHELP_UNLOAD.." Hit extractor \(double-tap to dump live rounds\)\n"
-		..WEPHELP_RELOAD.." Load round \(Hold "..WEPHELP_FIREMODE.." to force using 9mm\)\n"
+		LWPHELP_FIRE.." Close cylinder\n"
+		..LWPHELP_ALTFIRE.." Cycle cylinder \(Hold "..LWPHELP_ZOOM.." to reverse\)\n"
+		..LWPHELP_UNLOAD.." Hit extractor \(double-tap to dump live rounds\)\n"
+		..LWPHELP_RELOAD.." Load round \(Hold "..LWPHELP_FIREMODE.." to force using 9mm\)\n"
 		;
 		return
-		WEPHELP_FIRESHOOT
-		..WEPHELP_ALTFIRE.." Pull back hammer\n"
-		..WEPHELP_ALTRELOAD.."/"..WEPHELP_FIREMODE.."  Quick-Swap (if available)\n"
-		..WEPHELP_UNLOAD.."/"..WEPHELP_RELOAD.." Open cylinder\n"
+		LWPHELP_FIRESHOOT
+		..LWPHELP_ALTFIRE.." Pull back hammer\n"
+		..LWPHELP_ALTRELOAD.."/"..LWPHELP_FIREMODE.."  Quick-Swap (if available)\n"
+		..LWPHELP_UNLOAD.."/"..LWPHELP_RELOAD.." Open cylinder\n"
 		;
 	}
 

--- a/zscript/Snubnose Revolver/wep_snubnose.zs
+++ b/zscript/Snubnose Revolver/wep_snubnose.zs
@@ -97,18 +97,20 @@ class HDSnubNoseRevolver:HDHandgun{
 			);
 		}
 	}
+
 	override string gethelptext(){
+		LocalizeHelp();
 		if(cylinderopen)return
-		LWPHELP_FIRE.." Close cylinder\n"
-		..LWPHELP_ALTFIRE.." Cycle cylinder \(Hold "..LWPHELP_ZOOM.." to reverse\)\n"
-		..LWPHELP_UNLOAD.." Hit extractor \(double-tap to dump live rounds\)\n"
-		..LWPHELP_RELOAD.." Load round \(Hold "..LWPHELP_FIREMODE.." to force using 9mm\)\n"
+		LWPHELP_FIRE..Stringtable.Localize("$DSPR_HELPTEXT_1")
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$DSPR_HELPTEXT_2")..LWPHELP_ZOOM..Stringtable.Localize("$DSPR_HELPTEXT_3")
+		..LWPHELP_UNLOAD..Stringtable.Localize("$DSPR_HELPTEXT_4")
+		..LWPHELP_RELOAD..Stringtable.Localize("$DSPR_HELPTEXT_5")
 		;
 		return
 		LWPHELP_FIRESHOOT
-		..LWPHELP_ALTFIRE.." Pull back hammer\n"
-		..LWPHELP_ALTRELOAD.."/"..LWPHELP_FIREMODE.."  Quick-Swap (if available)\n"
-		..LWPHELP_UNLOAD.."/"..LWPHELP_RELOAD.." Open cylinder\n"
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$DSPR_HELPTEXT_6")
+		..LWPHELP_ALTRELOAD.."/"..LWPHELP_FIREMODE..Stringtable.Localize("$DSPR_HELPTEXT_7")
+		..LWPHELP_UNLOAD.."/"..LWPHELP_RELOAD..Stringtable.Localize("$DSPR_HELPTEXT_8")
 		;
 	}
 

--- a/zscript/StunGun/wep_stungun.zs
+++ b/zscript/StunGun/wep_stungun.zs
@@ -58,8 +58,8 @@ class HDStunGun:HDWeapon{//Tasers and stun guns are not the same, apparently
 	}
 	override string gethelptext(){
 		return
-		LWPHELP_FIRE.."  Zap\n"
-		..LWPHELP_ALTFIRE.."  Quick Prod\n"
+		LWPHELP_FIRE..Stringtable.Localize("$STUN_HELPTEXT_1")
+		..LWPHELP_ALTFIRE..Stringtable.Localize("$STUN_HELPTEXT_2")
 		..LWPHELP_RELOADRELOAD
 		..LWPHELP_UNLOADUNLOAD
 		;

--- a/zscript/StunGun/wep_stungun.zs
+++ b/zscript/StunGun/wep_stungun.zs
@@ -58,10 +58,10 @@ class HDStunGun:HDWeapon{//Tasers and stun guns are not the same, apparently
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRE.."  Zap\n"
-		..WEPHELP_ALTFIRE.."  Quick Prod\n"
-		..WEPHELP_RELOADRELOAD
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRE.."  Zap\n"
+		..LWPHELP_ALTFIRE.."  Quick Prod\n"
+		..LWPHELP_RELOADRELOAD
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	override double gunmass(){

--- a/zscript/TT-33/TokarevAutoReloader.zs
+++ b/zscript/TT-33/TokarevAutoReloader.zs
@@ -51,7 +51,7 @@ class TokarevAutoReloadingThingy:HDWeapon{
 		if(onpadd>0)owner.A_GiveInventory("HD762TokarevAmmo",onpadd);
 
 
-		owner.A_Log("You reloaded "..didmake.." 7.62 Tokarev rounds during your downtime, comrade.",true);
+		owner.A_Log(Stringtable.Localize("$TRRL_HELPTEXT_1")..didmake..Stringtable.Localize("$TRRL_HELPTEXT_2"),true);
 	}
 	override void actualpickup(actor other,bool silent){
 		super.actualpickup(other,silent);
@@ -170,8 +170,8 @@ class TokarevAutoReloader:TokarevAutoReloadingThingy{
 	}
 	override string gethelptext(){
 		return
-		LWPHELP_FIRE.."  Assemble 7.62 Tokarev rounds\n"
-		..LWPHELP_USE.."+"..LWPHELP_UNLOAD.."  same"
+		LWPHELP_FIRE..Stringtable.Localize("$TRRL_HELPTEXT_3")
+		..LWPHELP_USE.."+"..LWPHELP_UNLOAD..Stringtable.Localize("$TRRL_HELPTEXT_4")
 		;
 	}
 	override bool AddSpareWeapon(actor newowner){return AddSpareWeaponRegular(newowner);}

--- a/zscript/TT-33/TokarevAutoReloader.zs
+++ b/zscript/TT-33/TokarevAutoReloader.zs
@@ -170,8 +170,8 @@ class TokarevAutoReloader:TokarevAutoReloadingThingy{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRE.."  Assemble 7.62 Tokarev rounds\n"
-		..WEPHELP_USE.."+"..WEPHELP_UNLOAD.."  same"
+		LWPHELP_FIRE.."  Assemble 7.62 Tokarev rounds\n"
+		..LWPHELP_USE.."+"..LWPHELP_UNLOAD.."  same"
 		;
 	}
 	override bool AddSpareWeapon(actor newowner){return AddSpareWeaponRegular(newowner);}

--- a/zscript/TT-33/wep_TT33.zs
+++ b/zscript/TT-33/wep_TT33.zs
@@ -158,15 +158,15 @@ class HDTT33Pistol:HDHandgun{
 	}
 	override string gethelptext(){
 		return
-		WEPHELP_FIRESHOOT
-		..((weaponstatus[0]&PISF_SELECTFIRE)?(WEPHELP_FIREMODE.."  Semi/Auto\n"):"")
-	    ..WEPHELP_ALTFIRE.."  Rack slide\n"
-		..WEPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
-		..WEPHELP_RELOAD.."  Reload mag\n"
-		..WEPHELP_ALTFIRE.."+"..WEPHELP_RELOAD.."  Reload chamber\n"
-		..WEPHELP_ALTFIRE.."+"..WEPHELP_UNLOAD.."  Unload chamber/Clean pistol\n"
-		..WEPHELP_MAGMANAGER
-		..WEPHELP_UNLOADUNLOAD
+		LWPHELP_FIRESHOOT
+		..((weaponstatus[0]&PISF_SELECTFIRE)?(LWPHELP_FIREMODE.."  Semi/Auto\n"):"")
+	    ..LWPHELP_ALTFIRE.."  Rack slide\n"
+		..LWPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
+		..LWPHELP_RELOAD.."  Reload mag\n"
+		..LWPHELP_ALTFIRE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
+		..LWPHELP_ALTFIRE.."+"..LWPHELP_UNLOAD.."  Unload chamber/Clean pistol\n"
+		..LWPHELP_MAGMANAGER
+		..LWPHELP_UNLOADUNLOAD
 		;
 	}
 	override void DrawSightPicture(

--- a/zscript/TT-33/wep_TT33.zs
+++ b/zscript/TT-33/wep_TT33.zs
@@ -159,12 +159,12 @@ class HDTT33Pistol:HDHandgun{
 	override string gethelptext(){
 		return
 		LWPHELP_FIRESHOOT
-		..((weaponstatus[0]&PISF_SELECTFIRE)?(LWPHELP_FIREMODE.."  Semi/Auto\n"):"")
-	    ..LWPHELP_ALTFIRE.."  Rack slide\n"
-		..LWPHELP_ALTRELOAD.."  Quick-Swap (if available)\n"
-		..LWPHELP_RELOAD.."  Reload mag\n"
-		..LWPHELP_ALTFIRE.."+"..LWPHELP_RELOAD.."  Reload chamber\n"
-		..LWPHELP_ALTFIRE.."+"..LWPHELP_UNLOAD.."  Unload chamber/Clean pistol\n"
+		..((weaponstatus[0]&PISF_SELECTFIRE)?(LWPHELP_FIREMODE..Stringtable.Localize("$TT33_HELPTEXT_1")):"")
+	    ..LWPHELP_ALTFIRE..Stringtable.Localize("$TT33_HELPTEXT_2")
+		..LWPHELP_ALTRELOAD..Stringtable.Localize("$TT33_HELPTEXT_3")
+		..LWPHELP_RELOAD..Stringtable.Localize("$TT33_HELPTEXT_4")
+		..LWPHELP_ALTFIRE.."+"..LWPHELP_RELOAD..Stringtable.Localize("$TT33_HELPTEXT_5")
+		..LWPHELP_ALTFIRE.."+"..LWPHELP_UNLOAD..Stringtable.Localize("$TT33_HELPTEXT_6")
 		..LWPHELP_MAGMANAGER
 		..LWPHELP_UNLOADUNLOAD
 		;


### PR DESCRIPTION
Replaces all of the WEPHELP calls with LWPHELP and localizes the strings that accompany them. All strings from previous helptext were kept as is, minus fixing some typos, and are all ####_HELPTEXT_#, where the first four hashes are relating to the weapon and the last is the number accompanying that string.